### PR TITLE
Add role-aware workflows and external MCP support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Optional: connect to Jira MCP by URL (Streamable HTTP — no npm fetch, no subprocess). Can be local or hosted (e.g. cloud).
+# RELAY_JIRA_MCP_URL=http://localhost:4001
+# RELAY_JIRA_MCP_URL=https://your-mcp-host.example.com/jira
+
+# Optional: connect to Git/GitLab MCP by URL (Streamable HTTP). Can be local or hosted.
+# RELAY_GIT_MCP_URL=http://localhost:4002
+# RELAY_GITLAB_MCP_URL=https://your-mcp-host.example.com/git
+
+# Optional: disable Jira MCP if @red-hat/jira-mcp is not on your registry (check-in still works, no assigned issues)
+# RELAY_JIRA_MCP_DISABLED=1
+
+# Optional: disable Git MCP if @modelcontextprotocol/server-git is not on your registry (check-in still works, no branch/commits)
+# RELAY_GIT_MCP_DISABLED=1
+
+# Optional: Jira (when using a Jira MCP that is available)
+# RELAY_JIRA_BASE_URL=https://your-domain.atlassian.net
+# RELAY_JIRA_EMAIL=you@example.com
+# RELAY_JIRA_API_TOKEN=your-jira-personal-access-token
+
+# Optional: developer id for handoffs (defaults to $USER)
+# RELAY_DEVELOPER_ID=your-id
+
+# Optional: DB path (default: .relay/work-tracker.db in project or ~/.relay/relay.db)
+# RELAY_DB_PATH=.relay/work-tracker.db

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 # Local env files
 .env
 .env.*
+!.env.example
 .env.local
 *.local
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,12 +8,39 @@ When Relay runs as an MCP server (Cursor, Claude Desktop), it exposes:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `morning_checkin` | Pending handoffs, assigned issues, Git, active session | `developer_id?` |
-| `start_task` | Start work on Jira issue; create session and micro-tasks | `issue_key`, `micro_tasks?`, `developer_id?` |
-| `update_progress` | Log note, time, commit; optionally mark micro-task done | `session_id`, `note?`, `minutes_logged?`, `commit_sha?`, `complete_micro_task_id?` |
-| `complete_task` | End session, optional MR URL and total minutes; update Jira to Done | `session_id`, `merge_request_url?`, `total_minutes?` |
-| `create_handoff` | Create handoff to another developer | `to_developer_id`, `title`, `context_summary?`, `what_done?`, `what_next?`, `branch_name?`, `file_list?`, `blockers_notes?`, `work_session_id?`, `from_developer_id?` |
-| `end_of_day` | EOD summary and reminder to create handoffs | `developer_id?` |
+| `whats_up`, `status_check`, `get_context` | What's up? / Status check / Get context. Pending handoffs, assigned issues, Git, active session | `dev_name?` |
+| `start_task`, `begin_work` | Start task / Begin work on Jira issue; create session and micro-tasks | `task_id`, `dev_name`, `micro_tasks?` |
+| `log_work`, `update_status` | Log work / Update status. Note, time, commit; optionally mark micro-task done | `session_id`, `note?`, `minutes_logged?`, `commit_sha?`, `complete_micro_task_id?` |
+| `complete_task`, `finish_task` | Complete / finish task; end session, optional MR URL and total minutes; update Jira to Done | `session_id`, `merge_request_url?`, `total_minutes?` |
+| `handoff_task`, `transfer_to` | Handoff task / Transfer to. Create handoff to another developer | `to_developer_id`, `title`, `context_summary?`, `what_done?`, `what_next?`, `branch_name?`, `file_list?`, `blockers_notes?`, `work_session_id?`, `from_developer_id?` |
+| `end_session`, `pause_session`, `resume_session`, `session_summary` | End session / Pause / Resume / Session summary. EOD-style summary and handoff reminders | `dev_name?` |
+| `query_jira` | Query Jira. Call any Jira MCP (jiraMcp) tool by name | `tool_name`, `arguments?` (object) |
+| `query_gitlab` | Query GitLab. Call any GitLab MCP (RH-GITLAB-MCP) tool by name | `tool_name`, `arguments?` (object) |
+| `list_jira_mcp_tools` | List tools exposed by the Jira MCP | — |
+| `list_gitlab_mcp_tools` | List tools exposed by the GitLab MCP | — |
+| `show_roles` | Show roles. List persona roles (Engineer, Analyst, Scientist, Manager, Product/Process) | — |
+| `get_guidance` | Get guidance for a role so the coding model can tailor help (needs, Relay + MCP tools, example prompts) | `role` (engineer \| analyst \| scientist \| manager \| product_process) |
+| `role_aware_checkin` | Status check with role-specific emphasis and suggested focus | `role`, `dev_name?` |
+| `suggest_next` | Suggest next actions for the role using Relay and MCP (handoffs, start task, GitLab, etc.) | `role`, `context?`, `dev_name?` |
+| `active_tasks` | Show active tasks (current work session) | `dev_name?` |
+| `pending_handoffs` | Show pending handoffs | `dev_name?` |
+| `show_metrics` | Show metrics (session and handoff counts) | `dev_name?` |
+
+Use `list_jira_mcp_tools` and `list_gitlab_mcp_tools` to discover available tool names, then call them with `query_jira` or `query_gitlab` to utilise all tools from those MCPs.
+
+### Role-aware workflows
+
+Relay defines five **persona roles** so the coding-assistance model can tailor workflows and MCP usage:
+
+| Role id | Persona | Typical focus |
+|---------|---------|----------------|
+| `engineer` | Engineer | Jira + Git/GitLab (branch, MRs, pipelines); start/complete task, handoffs |
+| `analyst` | Analyst | Jira issues and acceptance criteria; handoffs; optional Git |
+| `scientist` | Scientist | Experiments, reproducibility (branch/commits), Jira for tracking |
+| `manager` | Manager | Pending handoffs, team/sprint status; Jira board/search by assignee |
+| `product_process` | Product / Process Manager | Backlog, issue details, MRs linked to stories |
+
+**Suggested flow for the coding model:** When the user indicates their role (e.g. “I’m an analyst” or “as a manager”), call `get_guidance` with that role, then use `role_aware_checkin` for a tailored check-in and `suggest_next` to recommend next steps. Use the suggested Relay and MCP tools from the guidance to make tasks easier for that persona.
 
 ### Resources
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ Get from zero to your first task in about 5 minutes.
 ## Prerequisites
 
 - **Required**: Node.js 18+, npm (and npx), network on first run (to fetch MCP packages), writable path for the workflow SQLite DB (default: `~/.relay/relay.db` or `.relay/work-tracker.db` in project).
-- **Optional**: **Jira** — set `JIRA_URL`, `JIRA_EMAIL`, `JIRA_TOKEN` (or `RELAY_JIRA_*`) for issues and status updates. **Git** — no config needed; Relay uses your local repo (current directory) for branch and commits. **Handoffs** — set `RELAY_DEVELOPER_ID` (defaults to `$USER`).
+- **Optional**: **Jira** — set `JIRA_URL`, `JIRA_EMAIL`, `JIRA_TOKEN` (or `RELAY_JIRA_*`) for issues and status updates. To use **already-running** Jira/Git MCP servers (no npm fetch): set **`RELAY_JIRA_MCP_URL`** and **`RELAY_GIT_MCP_URL`** (or **`RELAY_GITLAB_MCP_URL`**) to their Streamable HTTP URLs. **Git** — if not using a URL, Relay spawns a Git MCP for your local repo (branch and commits). **Handoffs** — set `RELAY_DEVELOPER_ID` (defaults to `$USER`).
 
 ## 1. Install
 
@@ -54,6 +54,8 @@ You’ll see pending handoffs, assigned Jira issues (if configured), current bra
 }
 ```
 
+**If using URL-based Jira/GitLab MCP:** Add `RELAY_JIRA_MCP_URL` and `RELAY_GIT_MCP_URL` (or `RELAY_GITLAB_MCP_URL`) to the `relay.env` block above with your MCP server URLs. Cursor only passes this `env` to Relay — not your shell or `.env` — so Relay will not see those variables unless they are in `mcp.json`.
+
 Restart Cursor. In chat you can ask: “Run my morning check-in”, “Start task PROJ-42”, etc. To disable Jira: set `RELAY_JIRA_MCP_DISABLED=1` in `env`.
 
 **VS Code** — Use the Relay extension (Command Palette → “Relay: Morning check-in”, etc.) or run `npx relay checkin` in the integrated terminal. Ensure `relay` or `npx relay` is in PATH.
@@ -61,6 +63,10 @@ Restart Cursor. In chat you can ask: “Run my morning check-in”, “Start tas
 **Claude Desktop** — Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows). Add the same `relay` entry under `mcpServers` as for Cursor, then restart Claude.
 
 **CLI only** — From repo root: `npx relay checkin`, `npx relay start PROJ-42`, etc. Or `cd packages/cli && npm link` then run `relay` from any directory.
+
+## Role-aware assistance
+
+Relay exposes **persona roles** (Engineer, Analyst, Scientist, Manager, Product/Process Manager) so the coding-assistance model can tailor help. In Cursor/Claude, say e.g. “I’m an analyst” or “run a check-in for a manager”; the model can call `show_roles`, `get_guidance`, `role_aware_checkin`, and `suggest_next` to adapt workflows and MCP usage to your role. See [API reference – Role-aware workflows](api-reference.md#role-aware-workflows).
 
 ## Next steps
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,17 @@
 
 ## CLI / MCP
 
+### 404 Not Found and “Access token expired” when running check-in
+
+- **@red-hat/jira-mcp** and **@modelcontextprotocol/server-git** are not on the public npm registry (Jira MCP is Red Hat internal; Git MCP may be under a different name or registry). So `npx relay checkin` can show 404s and “Access token expired” while it tries to start those MCPs. Check-in still completes; Jira and Git sections are just empty.
+- **Quiet check-in (no 404s):** disable the optional MCPs. In the project root create or edit **`.env`** and add:
+  ```bash
+  RELAY_JIRA_MCP_DISABLED=1
+  RELAY_GIT_MCP_DISABLED=1
+  ```
+  Or run: `RELAY_JIRA_MCP_DISABLED=1 RELAY_GIT_MCP_DISABLED=1 npx relay checkin`
+- **“Access token expired”** is from npm (e.g. a revoked or expired registry token). It doesn’t block check-in; fix with `npm login` or by removing any custom `npm config set //registry.npmjs.org/:_authToken` if you don’t need it.
+
 ### “No active session” when running update or complete
 
 - You must run **`relay start PROJ-42`** first (or have an active session from a previous start). Only one active session per developer is tracked.
@@ -9,9 +20,39 @@
 
 ### Jira MCP: 404 Not Found / Connection closed (`@red-hat/jira-mcp`)
 
-- Relay starts a Jira MCP server via **`npx -y @red-hat/jira-mcp`**. If that package is not on the registry you use (e.g. private npm) or you want to run without Jira:
+- Relay starts a Jira MCP server via **`npx -y @red-hat/jira-mcp`** unless you point it at an already-running server. If that package is not on the registry you use (e.g. private npm) or you want to run without Jira:
+  - **Connect to a Jira MCP by URL (recommended):** set **`RELAY_JIRA_MCP_URL`** to the server’s Streamable HTTP URL. Can be **local** (e.g. `http://localhost:4001`) or **hosted** (e.g. `https://mcp.your-company.com/jira`). Relay connects with `Accept: application/json, text/event-stream` to avoid **406 Not Acceptable** from strict MCP servers. No 404, no fetch.
   - **Disable Jira MCP:** set **`RELAY_JIRA_MCP_DISABLED=1`**. Check-in and start/complete will work; assigned issues will be empty and Jira won’t be updated.
-  - **Use a local or different Jira MCP:** set **`RELAY_JIRA_MCP_COMMAND`** (e.g. `node`) and **`RELAY_JIRA_MCP_ARGS`** (e.g. `/path/to/your/jira-mcp/run.js`). Relay will spawn that command instead of `npx @red-hat/jira-mcp`.
+  - **Use a local or different Jira MCP (spawn):** set **`RELAY_JIRA_MCP_COMMAND`** and **`RELAY_JIRA_MCP_ARGS`**. Examples: `node` + `/path/to/run.js`, or Python: `/path/to/venv/bin/python` + `/path/to/jira-mcp/server.py`. Relay passes **JIRA_URL**, **JIRA_TOKEN**, and **JIRA_API_TOKEN** (same value) to the subprocess so MCPs that expect **JIRA_API_TOKEN** work. Put these in `.env` in the project; the CLI loads `.env` from the current directory.
+  - If Jira MCP fails to start (e.g. package missing, network error), Relay now treats it as **non-fatal**: check-in still runs with “Assigned Jira issues: None (or Jira not configured).” You no longer get “Connection closed” from the Relay MCP for Jira failures.
+
+### Git MCP: 404 Not Found (`@modelcontextprotocol/server-git`)
+
+- Relay starts a Git MCP server via **`npx -y @modelcontextprotocol/server-git`** unless you point it at an already-running server. If that package is not in your registry or you want to run without it:
+  - **Connect to a Git/GitLab MCP by URL:** set **`RELAY_GIT_MCP_URL`** (or **`RELAY_GITLAB_MCP_URL`**) to the server’s Streamable HTTP URL. Can be local or hosted.
+  - **Run a local stdio Git/GitLab MCP (e.g. podman container):** set **`RELAY_GIT_MCP_COMMAND`** and **`RELAY_GIT_MCP_ARGS`** (comma-separated). Example for RH-GITLAB-MCP: `RELAY_GIT_MCP_COMMAND=podman`, `RELAY_GIT_MCP_ARGS=run,-i,--rm,--env-file,/path/to/.rh-gitlab-mcp.env,localhost/rh-gitlab-mcp:latest`. Relay will spawn that process and talk over stdio.
+  - **Disable Git MCP:** set **`RELAY_GIT_MCP_DISABLED=1`**. Check-in and start/complete will work; branch and recent commits will not be shown.
+
+### Relay not connecting to Jira or GitLab MCP (workflow / orchestration)
+
+If your Jira and GitLab MCP servers work when used directly but Relay check-in shows "None" for issues and Git:
+
+1. **Cursor / IDE:** Relay runs as a separate process started by Cursor. It only receives environment variables from the **Relay MCP server’s `env`** in `~/.cursor/mcp.json`. Your shell `export` or project `.env` are **not** passed. So you must set **`RELAY_JIRA_MCP_URL`** and **`RELAY_GIT_MCP_URL`** (or **`RELAY_GITLAB_MCP_URL`**) in the **`relay`** server’s `env` in `mcp.json`. Example:
+   ```json
+   "relay": {
+     "command": "npx",
+     "args": ["-y", "@relay/core"],
+     "env": {
+       "RELAY_DB_PATH": "${workspaceFolder}/.relay/work-tracker.db",
+       "RELAY_JIRA_MCP_URL": "http://localhost:4001",
+       "RELAY_GIT_MCP_URL": "http://localhost:4002"
+     }
+   }
+   ```
+   Use your actual URLs (and ports) where the Jira and GitLab MCP servers listen (Streamable HTTP).
+2. **CLI:** For `npx relay checkin`, Relay loads `.env` from the current directory. Put `RELAY_JIRA_MCP_URL` and `RELAY_GIT_MCP_URL` in that `.env`, or `export` them in the shell before running.
+3. **Protocol:** Relay connects via **Streamable HTTP** (MCP SDK `StreamableHTTPClientTransport`). Your Jira and GitLab MCP servers must expose that endpoint (not only stdio). If they use a different path (e.g. `/sse`), include it in the URL (e.g. `http://localhost:4001/sse`).
+4. **Restart:** After changing `mcp.json`, fully quit and restart Cursor so the Relay MCP process is restarted with the new env.
 
 ### Jira issues not showing in check-in
 
@@ -26,6 +67,12 @@
 - Ensure both use the same convention for developer id (e.g. Slack handle). There is no central server; “delivery” is the recipient’s next check-in on their machine.
 - **Solo developer:** If you hand off to yourself but don’t see it at check-in, the handoff was created with a different id (e.g. `"me"`). Create handoffs with **To** = your actual `RELAY_DEVELOPER_ID` so they show under “Pending handoffs.”
 
+### “Connection closed” when calling Relay MCP (e.g. morning check-in)
+
+- This usually means the Relay MCP process exited or lost its stdio connection. Relay now keeps running if Jira or Git MCP fail to start; only SQLite MCP is required.
+- If you see **“SQLite MCP failed to start”** in the tool error, install **mcp-sqlite** (`npx -y mcp-sqlite` should work) and ensure **RELAY_DB_PATH** (or **DATABASE_PATH** in MCP `env`) points to a writable path; the parent directory is created if missing.
+- Ensure only one Relay MCP process uses the same DB path. Restart Cursor after changing MCP config.
+
 ### MCP server not loading in Cursor / Claude
 
 - **Path**: In `mcp.json`, the `args` path to `run-mcp.js` must be absolute and correct. Prefer **`npx -y @relay/core`** so you don’t depend on a local path.
@@ -34,7 +81,7 @@
 
 ### Database locked or permission denied
 
-- **RELAY_DB_PATH** must point to a path where you can create and write a file (e.g. `~/.relay/relay.db`). On locked-down machines, set it to an allowed directory.
+- **RELAY_DB_PATH** must point to a path where you can create and write a file (e.g. `~/.relay/relay.db`). Default is `.relay/work-tracker.db` in the current directory; Relay creates the directory if missing. On locked-down machines, set **RELAY_DB_PATH** to an allowed directory.
 - Only one process should write to the same DB at a time; avoid running multiple Relay CLI/MCP instances with the same **RELAY_DB_PATH** if they write concurrently.
 
 ## VS Code extension

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/packages", "<rootDir>/tests"],
+  roots: ["<rootDir>/packages"],
+  passWithNoTests: true,
   testMatch: ["**/*.test.ts", "**/*.spec.ts"],
   collectCoverageFrom: ["packages/*/src/**/*.ts", "!**/*.d.ts", "!**/node_modules/**"],
   coverageThreshold: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "bin": {
+        "relay": "packages/cli/dist/index.js"
+      },
       "devDependencies": {
         "@relay/cli": "workspace:*",
         "@types/jest": "^29.5.12",
@@ -2166,16 +2169,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2674,23 +2667,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2852,29 +2828,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -3176,12 +3129,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3318,18 +3265,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -3481,21 +3416,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -3509,15 +3429,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3549,15 +3460,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3565,15 +3467,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3620,6 +3513,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -3677,15 +3582,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -3721,21 +3617,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4077,15 +3958,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -4263,12 +4135,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4354,63 +4220,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4428,12 +4237,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4557,12 +4360,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4722,21 +4519,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4911,12 +4693,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -6236,18 +6012,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -6268,16 +6032,11 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -6337,12 +6096,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6365,18 +6118,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6884,32 +6625,6 @@
         }
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6989,22 +6704,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -7092,30 +6791,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -7444,6 +7119,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7601,51 +7277,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7874,34 +7505,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -8230,18 +7833,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -8597,6 +8188,7 @@
         "@relay/core": "*",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
+        "dotenv": "^16.3.1",
         "inquirer": "^9.2.12",
         "nanoid": "^5.0.4",
         "ora": "^8.0.1"
@@ -8630,15 +8222,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "axios": "^1.6.7",
-        "better-sqlite3": "^12.6.0",
         "nanoid": "^5.0.4"
       },
       "bin": {
         "relay-mcp": "dist/run-mcp.js"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.8",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3"
       },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "relay",
   "version": "0.1.0",
   "private": true,
+  "bin": {
+    "relay": "./packages/cli/dist/index.js"
+  },
   "description": "AI-powered development workflow system for task handoffs, context preservation, and team coordination",
   "author": "Relay Contributors",
   "license": "MIT",
@@ -25,6 +28,7 @@
     "setup": "node scripts/setup.js",
     "migrate": "node scripts/migrate-db.js",
     "relay": "relay",
+    "checkin": "relay checkin",
     "dev": "npm run build && RELAY_JIRA_MCP_DISABLED=1 RELAY_GIT_MCP_DISABLED=1 RELAY_DB_PATH=/tmp/relay-dev.db node packages/cli/dist/index.js checkin"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
     "@relay/core": "*",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "dotenv": "^16.3.1",
     "inquirer": "^9.2.12",
     "ora": "^8.0.1",
     "nanoid": "^5.0.4"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "dotenv/config";
 import { Command } from "commander";
 import chalk from "chalk";
 import ora from "ora";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,3 +18,5 @@ export type {
 export { RelayOrchestrator } from "./orchestrator.js";
 export type { RelayOrchestratorOptions } from "./orchestrator.js";
 export { runMcpServer } from "./server.js";
+export { getRoleGuidance, listRoles, ROLE_GUIDANCE, RELAY_ROLE_IDS } from "./roles.js";
+export type { RelayRoleId, RoleGuidance } from "./roles.js";

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1,0 +1,196 @@
+/**
+ * Role definitions so Relay and the coding-assistance model can tailor workflows
+ * to Engineer, Analyst, Scientist, Manager, and Product/Process Manager needs.
+ * Use with get_guidance, role_aware_checkin, and suggest_next.
+ */
+
+export const RELAY_ROLE_IDS = [
+  "engineer",
+  "analyst",
+  "scientist",
+  "manager",
+  "product_process",
+] as const;
+
+export type RelayRoleId = (typeof RELAY_ROLE_IDS)[number];
+
+export interface RoleGuidance {
+  id: RelayRoleId;
+  label: string;
+  description: string;
+  /** What this role typically needs from tools and context */
+  needs: string[];
+  /** Relay tools to prioritize when assisting this role */
+  relayTools: string[];
+  /** How to use Jira MCP (list_jira_mcp_tools / query_jira) for this role */
+  jiraUsage: string;
+  /** How to use GitLab MCP for this role */
+  gitlabUsage: string;
+  /** Example user prompts the coding model should handle well */
+  examplePrompts: string[];
+}
+
+export const ROLE_GUIDANCE: Record<RelayRoleId, RoleGuidance> = {
+  engineer: {
+    id: "engineer",
+    label: "Engineer",
+    description: "Software or systems engineer shipping code, PRs/MRs, and Jira-linked work.",
+    needs: [
+      "Assigned Jira issues and sprint/backlog context",
+      "Current Git branch and recent commits",
+      "Start/complete tasks with Jira transitions and suggested branch names",
+      "Progress logs, micro-tasks, and handoffs",
+      "Merge/pull request links and pipeline status",
+    ],
+    relayTools: [
+      "whats_up",
+      "status_check",
+      "get_context",
+      "start_task",
+      "begin_work",
+      "log_work",
+      "update_status",
+      "complete_task",
+      "finish_task",
+      "handoff_task",
+      "transfer_to",
+      "list_gitlab_mcp_tools",
+      "query_gitlab",
+    ],
+    jiraUsage: "Search assigned issues, get issue details, transition to In Progress/Done. Use list_jira_mcp_tools then query_jira for search_issues, get_jira, transition_issue.",
+    gitlabUsage: "Branch status, recent commits, MRs, pipelines, list_merge_requests, list_pipelines. Use list_gitlab_mcp_tools to discover then query_gitlab.",
+    examplePrompts: [
+      "What's on my plate today?",
+      "Start working on PROJ-123",
+      "Log 30 minutes and link commit abc123",
+      "Mark task done and add MR link",
+      "Create a handoff to @alice for the auth refactor",
+    ],
+  },
+  analyst: {
+    id: "analyst",
+    label: "Analyst",
+    description: "Data or business analyst focused on reports, queries, and data quality.",
+    needs: [
+      "Jira issues for data/reporting requests and acceptance criteria",
+      "Context on datasets, pipelines, and dependencies",
+      "Links to runbooks, docs, and existing reports",
+      "Handoffs and status without deep Git workflow",
+    ],
+    relayTools: [
+      "whats_up",
+      "status_check",
+      "get_context",
+      "start_task",
+      "begin_work",
+      "log_work",
+      "complete_task",
+      "handoff_task",
+      "list_jira_mcp_tools",
+      "query_jira",
+    ],
+    jiraUsage: "Search issues by project/labels, get issue description and acceptance criteria. Use query_jira with search_issues (jql) or get_jira (issue_key).",
+    gitlabUsage: "Optional: list repos, list pipelines for data jobs. Use list_gitlab_mcp_tools then query_gitlab.",
+    examplePrompts: [
+      "What Jira issues are assigned to me?",
+      "Start PROJ-456 and break it into: validate source, build report, document",
+      "What handoffs do I have?",
+      "Summarize my active task and what's left",
+    ],
+  },
+  scientist: {
+    id: "scientist",
+    label: "Scientist",
+    description: "Research or data scientist running experiments, models, and reproducible workflows.",
+    needs: [
+      "Jira/epic context for experiments and papers",
+      "Reproducibility: branch, commit, and environment context",
+      "Links to runs, notebooks, and artifacts",
+      "Handoffs and collaboration context",
+    ],
+    relayTools: [
+      "whats_up",
+      "start_task",
+      "log_work",
+      "complete_task",
+      "handoff_task",
+      "list_gitlab_mcp_tools",
+      "query_gitlab",
+      "list_jira_mcp_tools",
+      "query_jira",
+    ],
+    jiraUsage: "Get issue details and link experiments to tickets. Use query_jira with get_jira, search_issues for epic/experiment tracking.",
+    gitlabUsage: "Branch, commits, and optionally CI for runs. Use query_gitlab for list_commits, branch info, pipelines.",
+    examplePrompts: [
+      "What am I working on and what branch?",
+      "Start experiment ticket EXP-1 with micro-tasks: setup env, run baseline, document results",
+      "Log progress and link commit for reproducibility",
+      "Hand off to @bob with run ID and notebook path",
+    ],
+  },
+  manager: {
+    id: "manager",
+    label: "Manager",
+    description: "Engineering or team manager focused on status, capacity, and handoffs.",
+    needs: [
+      "Pending handoffs and who is waiting",
+      "Team/sprint visibility (Jira board, issues by assignee)",
+      "Active sessions and blockers",
+      "Minimal code context; emphasis on status and next actions",
+    ],
+    relayTools: [
+      "whats_up",
+      "status_check",
+      "end_session",
+      "session_summary",
+      "handoff_task",
+      "list_jira_mcp_tools",
+      "query_jira",
+    ],
+    jiraUsage: "Board/sprint views, search by assignee or team. Use list_jira_mcp_tools then query_jira (e.g. search_issues with JQL by assignee/sprint).",
+    gitlabUsage: "Optional: pipeline status, MR list for team. Use list_gitlab_mcp_tools then query_gitlab.",
+    examplePrompts: [
+      "What handoffs are pending for my team?",
+      "Give me a status summary for the standup",
+      "Who has active work and what are they on?",
+      "End of day summary and handoff reminders",
+    ],
+  },
+  product_process: {
+    id: "product_process",
+    label: "Product / Process Manager",
+    description: "Product or process manager focused on backlogs, flows, and requirements.",
+    needs: [
+      "Backlog and sprint view (Jira)",
+      "Issue details, acceptance criteria, and links to implementation",
+      "Handoffs and dependency context",
+      "Visibility into MRs/commits linked to stories",
+    ],
+    relayTools: [
+      "whats_up",
+      "start_task",
+      "handoff_task",
+      "list_jira_mcp_tools",
+      "query_jira",
+      "list_gitlab_mcp_tools",
+      "query_gitlab",
+    ],
+    jiraUsage: "Search backlog, get issue, transition. Use query_jira with search_issues (JQL), get_jira, transition_issue.",
+    gitlabUsage: "MRs and pipelines linked to stories. Use query_gitlab with list_merge_requests, list_pipelines.",
+    examplePrompts: [
+      "What's in the backlog for this sprint?",
+      "Get details for PROJ-789",
+      "What handoffs are blocking delivery?",
+      "Summary of active work and MRs",
+    ],
+  },
+};
+
+export function getRoleGuidance(roleId: string): RoleGuidance | null {
+  const id = RELAY_ROLE_IDS.find((r) => r === roleId.toLowerCase());
+  return id ? ROLE_GUIDANCE[id] : null;
+}
+
+export function listRoles(): Array<{ id: RelayRoleId; label: string }> {
+  return RELAY_ROLE_IDS.map((id) => ({ id, label: ROLE_GUIDANCE[id].label }));
+}

--- a/packages/core/src/run-mcp.ts
+++ b/packages/core/src/run-mcp.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import { runMcpServer } from "./server.js";
 
+// Prevent unhandled rejections from closing the MCP connection (e.g. subprocess failures)
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled rejection:", reason);
+});
+
 runMcpServer().catch((err) => {
   console.error(err);
   process.exit(1);

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -13,36 +13,127 @@ import { updateProgressTool, runUpdateProgress } from "./tools/update-progress.j
 import { completeTaskTool, runCompleteTask } from "./tools/complete-task.js";
 import { createHandoffTool, runCreateHandoff } from "./tools/create-handoff.js";
 import { endOfDayTool, runEndOfDay } from "./tools/end-of-day.js";
+import {
+  getRoleGuidanceTool,
+  runGetRoleGuidance,
+  roleAwareCheckinTool,
+  runRoleAwareCheckin,
+  suggestActionsForRoleTool,
+  runSuggestActionsForRole,
+  listRolesTool,
+  runListRoles,
+} from "./tools/role-tools.js";
 
 const orchestrator = new RelayOrchestrator();
 
+const morningCheckinBase = {
+  ...morningCheckinTool(orchestrator as any),
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      dev_name: { type: "string", description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)" },
+    },
+  },
+};
+const startTaskBase = {
+  ...startTaskTool(orchestrator as any),
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      task_id: { type: "string", description: "Jira issue key (e.g. PROJ-42)" },
+      dev_name: { type: "string", description: "Developer id" },
+      micro_tasks: { type: "array", items: { type: "string" }, description: "Optional micro-task titles" },
+    },
+    required: ["task_id", "dev_name"],
+  },
+};
+const endSessionBase = {
+  ...endOfDayTool(orchestrator as any),
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      dev_name: { type: "string", description: "Developer id" },
+    },
+  },
+};
+
 const tools = [
-  {
-    ...morningCheckinTool(orchestrator as any),
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        dev_name: { type: "string", description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)" },
-      },
-    },
-  },
-  {
-    ...startTaskTool(orchestrator as any),
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        task_id: { type: "string", description: "Jira issue key (e.g. PROJ-42)" },
-        dev_name: { type: "string", description: "Developer id" },
-        micro_tasks: { type: "array", items: { type: "string" }, description: "Optional micro-task titles" },
-      },
-      required: ["task_id", "dev_name"],
-    },
-  },
+  morningCheckinBase,
+  { ...morningCheckinBase, name: "status_check" },
+  { ...morningCheckinBase, name: "get_context" },
+  startTaskBase,
+  { ...startTaskBase, name: "begin_work" },
   updateProgressTool(orchestrator as any),
+  { ...updateProgressTool(orchestrator as any), name: "update_status" },
   completeTaskTool(orchestrator as any),
+  { ...completeTaskTool(orchestrator as any), name: "finish_task" },
   createHandoffTool(orchestrator as any),
+  { ...createHandoffTool(orchestrator as any), name: "transfer_to" },
+  endSessionBase,
+  { ...endSessionBase, name: "pause_session" },
+  { ...endSessionBase, name: "resume_session" },
+  { ...endSessionBase, name: "session_summary" },
   {
-    ...endOfDayTool(orchestrator as any),
+    name: "query_jira",
+    description: "Query Jira. Call any tool from the Jira MCP by name (e.g. search_issues, get_issue, transition_issue). Use list_jira_mcp_tools to see available tools.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tool_name: { type: "string", description: "Name of the Jira MCP tool to call" },
+        arguments: { type: "object", description: "Arguments to pass to the tool (key-value object)" },
+      },
+      required: ["tool_name"],
+    },
+  },
+  {
+    name: "query_gitlab",
+    description: "Query GitLab. Call any tool from the GitLab MCP by name. Use list_gitlab_mcp_tools to see available tools.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tool_name: { type: "string", description: "Name of the GitLab MCP tool to call" },
+        arguments: { type: "object", description: "Arguments to pass to the tool (key-value object)" },
+      },
+      required: ["tool_name"],
+    },
+  },
+  {
+    name: "list_jira_mcp_tools",
+    description: "List all tools exposed by the Jira MCP. Use before query_jira to discover tool names.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "list_gitlab_mcp_tools",
+    description: "List all tools exposed by the GitLab MCP. Use before query_gitlab to discover tool names.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  getRoleGuidanceTool(),
+  roleAwareCheckinTool(orchestrator.getWorkflowManager()),
+  suggestActionsForRoleTool(),
+  listRolesTool(),
+  {
+    name: "active_tasks",
+    description: "Show active tasks. Returns current work session for the developer.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        dev_name: { type: "string", description: "Developer id" },
+      },
+    },
+  },
+  {
+    name: "pending_handoffs",
+    description: "Show pending handoffs. Returns handoffs waiting for the developer.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        dev_name: { type: "string", description: "Developer id" },
+      },
+    },
+  },
+  {
+    name: "show_metrics",
+    description: "Show metrics. Session and handoff counts for the developer.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -77,28 +168,113 @@ export async function runMcpServer(): Promise<void> {
     try {
       let text: string;
       switch (name) {
-        case "morning_checkin":
+        case "whats_up":
+        case "status_check":
+        case "get_context":
           text = await runMorningCheckin(orchestrator as any, { developer_id: devId });
           break;
         case "start_task":
+        case "begin_work":
           text = await runStartTask(orchestrator as any, {
             issue_key: (a.task_id ?? a.issue_key) as string,
             micro_tasks: a.micro_tasks as string[] | undefined,
             developer_id: devId,
           });
           break;
-        case "update_progress":
+        case "log_work":
+        case "update_status":
           text = await runUpdateProgress(orchestrator as any, { ...a, developer_id: devId } as any);
           break;
         case "complete_task":
+        case "finish_task":
           text = await runCompleteTask(orchestrator as any, a as { session_id: string; merge_request_url?: string; total_minutes?: number });
           break;
-        case "create_handoff":
+        case "handoff_task":
+        case "transfer_to":
           text = await runCreateHandoff(orchestrator as any, { ...a, from_developer_id: devId } as any);
           break;
-        case "end_of_day":
+        case "end_session":
+        case "pause_session":
+        case "resume_session":
+        case "session_summary":
           text = await runEndOfDay(orchestrator as any, { developer_id: devId });
           break;
+        case "query_jira": {
+          const toolName = a.tool_name as string;
+          const toolArgs = (a.arguments ?? a.args ?? {}) as Record<string, unknown>;
+          const out = await orchestrator.callJiraMcpTool(toolName, toolArgs);
+          text = out.isError ? `Error: ${out.content}` : out.content;
+          break;
+        }
+        case "query_gitlab": {
+          const toolName = a.tool_name as string;
+          const toolArgs = (a.arguments ?? a.args ?? {}) as Record<string, unknown>;
+          const out = await orchestrator.callGitlabMcpTool(toolName, toolArgs);
+          text = out.isError ? `Error: ${out.content}` : out.content;
+          break;
+        }
+        case "list_jira_mcp_tools": {
+          const list = await orchestrator.listJiraMcpTools();
+          text = list.length
+            ? list.map((t) => `- **${t.name}**: ${t.description ?? ""}`).join("\n")
+            : "No Jira MCP connected or no tools returned.";
+          break;
+        }
+        case "list_gitlab_mcp_tools": {
+          const list = await orchestrator.listGitlabMcpTools();
+          text = list.length
+            ? list.map((t) => `- **${t.name}**: ${t.description ?? ""}`).join("\n")
+            : "No GitLab MCP connected or no tools returned.";
+          break;
+        }
+        case "get_guidance":
+          text = await runGetRoleGuidance({ role: (a.role as string) ?? "engineer" });
+          break;
+        case "role_aware_checkin":
+          text = await runRoleAwareCheckin(orchestrator.getWorkflowManager(), {
+            role: a.role as string,
+            developer_id: devId,
+            dev_name: devId,
+          });
+          break;
+        case "suggest_next":
+          text = await runSuggestActionsForRole(orchestrator.getWorkflowManager(), {
+            role: a.role as string,
+            context: a.context as string | undefined,
+            developer_id: devId,
+            dev_name: devId,
+          });
+          break;
+        case "show_roles":
+          text = await runListRoles();
+          break;
+        case "active_tasks": {
+          const db = orchestrator.getDb();
+          const session = await db.getActiveSession(devId ?? process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default");
+          text = session
+            ? `Active session: **${session.id}** — Jira: ${session.jira_issue_key ?? "none"}`
+            : "No active session.";
+          break;
+        }
+        case "pending_handoffs": {
+          const db = orchestrator.getDb();
+          const handoffs = await db.getPendingHandoffs(devId ?? process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default");
+          text = handoffs.length
+            ? handoffs.map((h) => `- **${h.title}** (from ${h.from_developer_id})${h.context_summary ? ` — ${h.context_summary}` : ""}`).join("\n")
+            : "No pending handoffs.";
+          break;
+        }
+        case "show_metrics": {
+          const db = orchestrator.getDb();
+          const dev = devId ?? process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default";
+          const session = await db.getActiveSession(dev);
+          const handoffs = await db.getPendingHandoffs(dev);
+          text = [
+            `Active session: ${session ? "yes" : "no"}${session ? ` (${session.id})` : ""}`,
+            `Pending handoffs: ${handoffs.length}`,
+          ].join("\n");
+          break;
+        }
         default:
           text = `Unknown tool: ${name}`;
       }

--- a/packages/core/src/tools/complete-task.ts
+++ b/packages/core/src/tools/complete-task.ts
@@ -5,7 +5,7 @@ export function completeTaskTool(_wm: WorkflowManager): Tool {
   return {
     name: "complete_task",
     description:
-      "Complete the current work session: set status to done, optionally link MR/PR URL and total time. Updates Jira to Done.",
+      "Complete task / Finish task. End work session, optionally link MR/PR URL and total time. Updates Jira to Done.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/core/src/tools/create-handoff.ts
+++ b/packages/core/src/tools/create-handoff.ts
@@ -3,9 +3,9 @@ import type { WorkflowManager } from "../workflow-manager.js";
 
 export function createHandoffTool(_wm: WorkflowManager): Tool {
   return {
-    name: "create_handoff",
+    name: "handoff_task",
     description:
-      "Create a handoff to another developer: capture context, what's done, what's next, branch and file list. Marks current work session as handed off.",
+      "Handoff task / Transfer to. Create a handoff to another developer: capture context, what's done, what's next, branch and file list. Marks current work session as handed off.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/core/src/tools/end-of-day.ts
+++ b/packages/core/src/tools/end-of-day.ts
@@ -3,9 +3,9 @@ import type { WorkflowManager } from "../workflow-manager.js";
 
 export function endOfDayTool(_wm: WorkflowManager): Tool {
   return {
-    name: "end_of_day",
+    name: "end_session",
     description:
-      "End-of-day summary: show completed work, pending handoffs, and suggest creating handoffs for any active session.",
+      "End session / Pause session / Resume session / Session summary. Show completed work, pending handoffs, and suggest creating handoffs for any active session.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/core/src/tools/morning-checkin.ts
+++ b/packages/core/src/tools/morning-checkin.ts
@@ -3,9 +3,9 @@ import type { WorkflowManager } from "../workflow-manager.js";
 
 export function morningCheckinTool(_wm: WorkflowManager): Tool {
   return {
-    name: "morning_checkin",
+    name: "whats_up",
     description:
-      "Run a morning check-in: list pending handoffs (from overnight), assigned Jira issues, current Git branch, and recent commits. Recommends priority order.",
+      "What's up? / Status check / Get context. List pending handoffs, assigned Jira issues, current Git branch, and recent commits. Recommends priority order.",
     inputSchema: {
       type: "object",
       properties: {
@@ -38,10 +38,13 @@ export async function runMorningCheckin(
     "### Assigned Jira issues",
     result.assignedIssues.length
       ? result.assignedIssues.map((i) => `- ${i.key}: ${i.summary}`).join("\n")
-      : "None (or Jira not configured).",
+      : result.jiraError
+        ? `None (Jira MCP: ${result.jiraError}).`
+        : "None (or Jira not configured).",
     "",
     "### Git",
     `- Branch: ${result.currentBranch || "N/A"}`,
+    ...(result.gitError ? [`  _${result.gitError}_`] : []),
     result.recentCommits.length
       ? "Recent commits:\n" +
         result.recentCommits.map((c) => `  - ${c.sha.slice(0, 7)} ${c.message}`).join("\n")

--- a/packages/core/src/tools/role-tools.ts
+++ b/packages/core/src/tools/role-tools.ts
@@ -1,0 +1,230 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { WorkflowManager } from "../workflow-manager.js";
+import {
+  getRoleGuidance,
+  listRoles,
+  ROLE_GUIDANCE,
+  type RelayRoleId,
+} from "../roles.js";
+import { runMorningCheckin } from "./morning-checkin.js";
+
+const ROLE_IDS_DESC = "engineer | analyst | scientist | manager | product_process";
+
+export function getRoleGuidanceTool(): Tool {
+  return {
+    name: "get_guidance",
+    description:
+      "Get guidance for your role (Engineer, Analyst, Scientist, Manager, Product/Process). Use when the user says they are an engineer/analyst/scientist/manager/product manager to understand their needs and which Relay + MCP tools to use.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        role: {
+          type: "string",
+          description: `Role id: ${ROLE_IDS_DESC}`,
+          enum: ["engineer", "analyst", "scientist", "manager", "product_process"],
+        },
+      },
+      required: ["role"],
+    },
+  };
+}
+
+export async function runGetRoleGuidance(args: { role: string }): Promise<string> {
+  const guidance = getRoleGuidance(args.role);
+  if (!guidance) {
+    const roles = listRoles();
+    return `Unknown role: "${args.role}". Use one of: ${roles.map((r) => r.id).join(", ")}.`;
+  }
+  const lines = [
+    `# ${guidance.label}`,
+    "",
+    guidance.description,
+    "",
+    "## What this role typically needs",
+    ...guidance.needs.map((n) => `- ${n}`),
+    "",
+    "## Relay tools to use",
+    guidance.relayTools.join(", "),
+    "",
+    "## Jira MCP",
+    guidance.jiraUsage,
+    "",
+    "## GitLab MCP",
+    guidance.gitlabUsage,
+    "",
+    "## Example prompts to handle",
+    ...guidance.examplePrompts.map((p) => `- "${p}"`),
+  ];
+  return lines.join("\n");
+}
+
+export function roleAwareCheckinTool(_wm: WorkflowManager): Tool {
+  return {
+    name: "role_aware_checkin",
+    description:
+      "Status check tailored to the user's role (Engineer, Analyst, Scientist, Manager, Product/Process). Same data as whats_up/status_check but with role-specific emphasis. Use with get_guidance when assisting an engineer/analyst/scientist/manager/product manager.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        role: {
+          type: "string",
+          description: `Role id: ${ROLE_IDS_DESC}`,
+          enum: ["engineer", "analyst", "scientist", "manager", "product_process"],
+        },
+        dev_name: {
+          type: "string",
+          description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)",
+        },
+      },
+      required: ["role"],
+    },
+  };
+}
+
+export async function runRoleAwareCheckin(
+  wm: WorkflowManager,
+  args: { role: string; developer_id?: string; dev_name?: string }
+): Promise<string> {
+  const roleId = args.role?.toLowerCase() as RelayRoleId;
+  const devId = args.developer_id ?? args.dev_name;
+  const guidance = getRoleGuidance(roleId);
+  const checkinText = await runMorningCheckin(wm, { developer_id: devId });
+
+  if (!guidance) {
+    return checkinText;
+  }
+
+  const focusByRole: Record<RelayRoleId, string> = {
+    engineer: "Focus: assigned issues, branch, and active session. Use start_task, log_work, complete_task, and GitLab MRs.",
+    analyst: "Focus: assigned Jira issues and handoffs. Use start_task and Jira for acceptance criteria; Git is optional.",
+    scientist: "Focus: branch/commits for reproducibility, Jira for experiment tracking, handoffs with run/notebook context.",
+    manager: "Focus: pending handoffs and team status. Use query_jira for board/sprint; minimal Git detail.",
+    product_process: "Focus: backlog and issue details. Use query_jira; query_gitlab for MRs linked to stories.",
+  };
+  const focus = focusByRole[roleId];
+  const header = [
+    "## Role-aware check-in",
+    "",
+    `**Role:** ${guidance.label}`,
+    "",
+    `**Suggested focus:** ${focus}`,
+    "",
+    "---",
+    "",
+  ].join("\n");
+
+  return header + checkinText;
+}
+
+export function suggestActionsForRoleTool(): Tool {
+  return {
+    name: "suggest_next",
+    description:
+      "Suggest next actions for the given role using Relay and MCP. Use after role_aware_checkin or when the user asks 'what should I do next'. Combines role guidance with handoffs/issues/active session to recommend concrete steps.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        role: {
+          type: "string",
+          description: `Role id: ${ROLE_IDS_DESC}`,
+          enum: ["engineer", "analyst", "scientist", "manager", "product_process"],
+        },
+        context: {
+          type: "string",
+          description:
+            "Optional: e.g. 'just finished a task', 'no active session', 'has pending handoffs'. Improves suggestions.",
+        },
+        dev_name: {
+          type: "string",
+          description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)",
+        },
+      },
+    },
+  };
+}
+
+export async function runSuggestActionsForRole(
+  wm: WorkflowManager,
+  args: { role: string; context?: string; developer_id?: string; dev_name?: string }
+): Promise<string> {
+  const roleId = args.role?.toLowerCase() as RelayRoleId;
+  const devId = args.developer_id ?? args.dev_name;
+  const guidance = getRoleGuidance(roleId);
+  if (!guidance) {
+    const roles = listRoles();
+    return `Unknown role: "${args.role}". Use one of: ${roles.map((r) => r.id).join(", ")}.`;
+  }
+
+  const checkin = await wm.morningCheckin(devId);
+  const hasHandoffs = checkin.pendingHandoffs.length > 0;
+  const hasIssues = checkin.assignedIssues.length > 0;
+  const hasActiveSession = checkin.activeSession != null;
+  const ctx = (args.context ?? "").toLowerCase();
+
+  const suggestions: string[] = [];
+
+  if (guidance.id === "manager" || guidance.id === "product_process") {
+    if (hasHandoffs) {
+      suggestions.push("1. **Review pending handoffs** — Check relay:///pending-handoffs or whats_up/status_check output and follow up with owners.");
+    }
+      suggestions.push("2. **Get team/sprint view** — Use query_jira with search_issues (JQL by assignee or sprint) for standup or status.");
+    if (guidance.id === "product_process") {
+      suggestions.push("3. **Check backlog** — Use query_jira (search_issues) with JQL for open/sprint issues.");
+    }
+  } else {
+    if (hasHandoffs) {
+      suggestions.push("1. **Address pending handoffs** — Use whats_up/status_check to see details; handoff_task if you're passing work.");
+    }
+    if (!hasActiveSession && hasIssues) {
+      suggestions.push(
+        "2. **Start a task** — Use start_task with an issue key (e.g. from assigned issues) to create a session and get a suggested branch."
+      );
+    }
+    if (hasActiveSession) {
+      suggestions.push("2. **Continue current task** — Use log_work to log time/notes/commits; complete_task when done with optional MR link.");
+    }
+    if ((guidance.id === "engineer" || guidance.id === "scientist") && !suggestions.some((s) => s.includes("GitLab"))) {
+      suggestions.push("3. **Check GitLab** — Use query_gitlab (or list_gitlab_mcp_tools) for MRs, pipelines, or recent commits.");
+    }
+  }
+
+  if (ctx.includes("finished") || ctx.includes("done")) {
+    suggestions.unshift("**You mentioned you just finished.** Consider: complete_task (with session_id and optional merge_request_url), then start_task for the next issue or suggest_next to reprioritize.");
+  }
+
+  const lines = [
+    `# Suggested actions (${guidance.label})`,
+    "",
+    ...(args.context ? [`Context: ${args.context}`, ""] : []),
+    "## Recommended next steps",
+    "",
+    ...suggestions,
+    "",
+    "## Tools to use",
+    guidance.relayTools.slice(0, 6).join(", ") + (guidance.relayTools.length > 6 ? ", …" : ""),
+  ].filter(Boolean);
+
+  return lines.join("\n");
+}
+
+export function listRolesTool(): Tool {
+  return {
+    name: "show_roles",
+    description:
+      "Show roles. List Relay persona roles (Engineer, Analyst, Scientist, Manager, Product/Process Manager). Use before get_guidance or role_aware_checkin when the user's role is unclear.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runListRoles(): Promise<string> {
+  const roles = listRoles();
+  const lines = [
+    "Relay roles (use with get_guidance, role_aware_checkin, suggest_next):",
+    "",
+    ...roles.map((r) => {
+      const g = ROLE_GUIDANCE[r.id];
+      return `- **${r.id}** — ${g.description}`;
+    }),
+  ];
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/start-task.ts
+++ b/packages/core/src/tools/start-task.ts
@@ -5,7 +5,7 @@ export function startTaskTool(_wm: WorkflowManager): Tool {
   return {
     name: "start_task",
     description:
-      "Start working on a Jira issue: fetch details, create work session, optionally break into micro-tasks. Suggests Git branch name. Updates Jira to In Progress.",
+      "Start task / Begin work. Start working on a Jira issue: fetch details, create work session, optionally break into micro-tasks. Suggests Git branch name. Updates Jira to In Progress.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/core/src/tools/update-progress.ts
+++ b/packages/core/src/tools/update-progress.ts
@@ -3,9 +3,9 @@ import type { WorkflowManager } from "../workflow-manager.js";
 
 export function updateProgressTool(_wm: WorkflowManager): Tool {
   return {
-    name: "update_progress",
+    name: "log_work",
     description:
-      "Log progress on the current work session: add a note, log time, link a commit, or mark a micro-task done.",
+      "Log work / Update status. Add a note, log time, link a commit, or mark a micro-task done on the current work session.",
     inputSchema: {
       type: "object",
       properties: {

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -5,10 +5,22 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const readline = require("readline");
 
 const RELAY_HOME = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
 
-function main() {
+function askToContinue() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question("Run Relay setup now? (creates ~/.relay, env.example) [Y/n] ", (answer) => {
+      rl.close();
+      const normalized = (answer || "y").trim().toLowerCase();
+      resolve(normalized === "" || normalized === "y" || normalized === "yes");
+    });
+  });
+}
+
+function runSetup() {
   if (!fs.existsSync(RELAY_HOME)) {
     fs.mkdirSync(RELAY_HOME, { recursive: true });
     console.log("Created", RELAY_HOME);
@@ -18,6 +30,10 @@ function main() {
   const randomId = require("crypto").randomBytes(8).toString("hex");
   const envContent = `# Relay configuration (copy to .env or export)
 # RELAY_DB_PATH=${path.join(RELAY_HOME, "relay.db")}
+# Disable Jira MCP if you get 404 for @red-hat/jira-mcp or don't use Jira (check-in still works, no assigned issues):
+# RELAY_JIRA_MCP_DISABLED=1
+# Disable Git MCP if you get 404 for @modelcontextprotocol/server-git (check-in still works, no branch/commits):
+# RELAY_GIT_MCP_DISABLED=1
 # Jira (optional) — RELAY_JIRA_API_TOKEN = Jira Personal Access Token
 # RELAY_JIRA_BASE_URL=https://your-domain.atlassian.net
 # RELAY_JIRA_EMAIL=you@example.com
@@ -32,8 +48,21 @@ function main() {
 
   console.log("Relay setup complete. Next:");
   console.log("  1. Configure (optional): set RELAY_JIRA_BASE_URL, RELAY_JIRA_EMAIL, RELAY_JIRA_API_TOKEN (Jira PAT), RELAY_DEVELOPER_ID — or copy", envExample);
-  console.log("  2. Install CLI: npm install -g @relay/cli  (or use npx)");
-  console.log("  3. Run: relay checkin");
+  console.log("     If you don't use Jira or get 404 for @red-hat/jira-mcp: set RELAY_JIRA_MCP_DISABLED=1.");
+  console.log("     If you get 404 for @modelcontextprotocol/server-git: set RELAY_GIT_MCP_DISABLED=1 (in .env or export).");
+  console.log("  2. From this repo:  npm run build   then run check-in with either:");
+  console.log("        npx relay checkin    (use npx, not npm)");
+  console.log("        npm run checkin");
+  console.log("     Or install globally:  npm install -g @relay/cli   then run  relay checkin  from anywhere");
+}
+
+async function main() {
+  const ok = await askToContinue();
+  if (!ok) {
+    console.log("Setup cancelled.");
+    process.exit(0);
+  }
+  runSetup();
 }
 
 main();


### PR DESCRIPTION
Introduce persona roles and role-aware workflows across the project and make Relay more flexible when connecting to MCPs. Add .env.example and update .gitignore so example env is tracked. Extensive docs updated (API reference, Getting Started, Troubleshooting) to document new role APIs, RELAY_JIRA_MCP_URL / RELAY_GIT_MCP_URL (Streamable HTTP) usage, MCP spawn/disable options, and improved guidance for common MCP connection errors. Implement role-related code (new roles.ts, role-tools.ts) and update core/CLI files and tools to support role-aware check-ins, guidance, and more resilient MCP startup behavior. Also relax Jest roots and allow passing with no tests via jest.config.js.

## Description
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist
- [ ] Tests pass locally (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if needed)
- [ ] Follows branch convention (feature/*, release/*, hotfix/*)

## Related issues
<!-- Link any related issues: Fixes #123 -->
