### PR TITLE
Add orchestration flows, tools, and Jira support

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,31 +2,84 @@
 
 ## MCP server (Relay as MCP)
 
-When Relay runs as an MCP server (Cursor, Claude Desktop), it exposes:
+When Relay runs as an MCP server (Cursor, Claude Desktop), it exposes **65 tools** (including aliases such as `status_check` / `whats_up` and `begin_work` / `start_task`). The sections below group them by purpose. Required parameters are listed first; optional parameters are suffixed with `?`.
 
-### Tools
+### Core workflow tools
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `whats_up`, `status_check`, `get_context` | What's up? / Status check / Get context. Pending handoffs, assigned issues, Git, active session | `dev_name?` |
-| `start_task`, `begin_work` | Start task / Begin work on Jira issue; create session and micro-tasks | `task_id`, `dev_name`, `micro_tasks?` |
-| `log_work`, `update_status` | Log work / Update status. Note, time, commit; optionally mark micro-task done | `session_id`, `note?`, `minutes_logged?`, `commit_sha?`, `complete_micro_task_id?` |
-| `complete_task`, `finish_task` | Complete / finish task; end session, optional MR URL and total minutes; update Jira to Done | `session_id`, `merge_request_url?`, `total_minutes?` |
-| `handoff_task`, `transfer_to` | Handoff task / Transfer to. Create handoff to another developer | `to_developer_id`, `title`, `context_summary?`, `what_done?`, `what_next?`, `branch_name?`, `file_list?`, `blockers_notes?`, `work_session_id?`, `from_developer_id?` |
-| `end_session`, `pause_session`, `resume_session`, `session_summary` | End session / Pause / Resume / Session summary. EOD-style summary and handoff reminders | `dev_name?` |
-| `query_jira` | Query Jira. Call any Jira MCP (jiraMcp) tool by name | `tool_name`, `arguments?` (object) |
-| `query_gitlab` | Query GitLab. Call any GitLab MCP (RH-GITLAB-MCP) tool by name | `tool_name`, `arguments?` (object) |
-| `list_jira_mcp_tools` | List tools exposed by the Jira MCP | — |
-| `list_gitlab_mcp_tools` | List tools exposed by the GitLab MCP | — |
-| `show_roles` | Show roles. List persona roles (Engineer, Analyst, Scientist, Manager, Product/Process) | — |
-| `get_guidance` | Get guidance for a role so the coding model can tailor help (needs, Relay + MCP tools, example prompts) | `role` (engineer \| analyst \| scientist \| manager \| product_process) |
-| `role_aware_checkin` | Status check with role-specific emphasis and suggested focus | `role`, `dev_name?` |
-| `suggest_next` | Suggest next actions for the role using Relay and MCP (handoffs, start task, GitLab, etc.) | `role`, `context?`, `dev_name?` |
-| `active_tasks` | Show active tasks (current work session) | `dev_name?` |
-| `pending_handoffs` | Show pending handoffs | `dev_name?` |
-| `show_metrics` | Show metrics (session and handoff counts) | `dev_name?` |
+| `whats_up`, `status_check`, `get_context` | What's up? / Status check / Get context. Pending handoffs, assigned Jira issues, Git branch/commits, active session. | `dev_name?` |
+| `start_task`, `begin_work` | Start task / Begin work on a Jira issue; create work session and optional micro-tasks; suggest branch name; update Jira to In Progress. | `task_id`, `dev_name`, `micro_tasks?` |
+| `log_work`, `update_status` | Log work / Update status. Add note, log time, link commit SHA, or mark a micro-task done on the current session. | `session_id`, `note?`, `minutes_logged?`, `commit_sha?`, `complete_micro_task_id?`, `developer_id?` |
+| `complete_task`, `finish_task` | Complete / finish task. End work session; optionally link MR/PR URL and total minutes. Updates Jira to Done. | `session_id`, `merge_request_url?`, `total_minutes?` |
+| `handoff_task`, `transfer_to` | Handoff task / Transfer to. Create handoff to another developer. If `merge_request_url` is set (and active session or `jira_issue_key`), adds a Jira comment with the MR link. Marks session as handed off. | `to_developer_id`, `title`, `context_summary?`, `what_done?`, `what_next?`, `branch_name?`, `file_list?`, `blockers_notes?`, `work_session_id?`, `from_developer_id?`, `merge_request_url?`, `jira_issue_key?` |
+| `end_session`, `pause_session`, `resume_session`, `session_summary` | End session / Pause / Resume / Session summary. EOD-style summary and handoff reminders. | `dev_name?` |
 
-Use `list_jira_mcp_tools` and `list_gitlab_mcp_tools` to discover available tool names, then call them with `query_jira` or `query_gitlab` to utilise all tools from those MCPs.
+### Jira + GitLab combined tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `create_subtask_from_mr_review` | **Jira + GitLab:** If the MR has review comments requiring changes, create a Jira sub-task under the parent issue. Relay checks GitLab MR notes/discussions and creates the sub-task via Jira MCP. | `jira_issue_key`, `merge_request_url?`, `project_id?`, `project_name?`, `mr_iid?`, `merge_request_id?` |
+| `smart_handoff` | **Smart handoff:** Find GitLab MR for the task, analyze review comments, create Jira sub-tasks per change, add handoff comment to Jira, create handoff record. | `task_id`, `from_dev`, `to_dev`, `auto_analyze?`, `custom_notes?`, `project_id?`, `project_name?`, `merge_request_url?`, `mr_iid?` |
+| `review_readiness_check` | **Ready for review?** Check Jira sub-tasks complete, GitLab pipeline and conflicts, work session state; return blockers or “ready” with next steps (e.g. request reviewers). | `task_id`, `dev_name?` |
+| `context_resurrection` | **Return from time away:** Summarize last work session, Jira updates on your task, GitLab branch/conflicts; “where you left off” and next steps. | `dev_name?`, `days_away?` |
+
+### Jira / GitLab passthrough and discovery
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `query_jira` | Call any Jira MCP tool by name (e.g. `search_issues`, `get_issue`, `transition_issue`). Use `list_jira_mcp_tools` to discover tool names. | `tool_name`, `arguments?` (object) |
+| `query_gitlab` | Call any GitLab MCP tool by name. Use `list_gitlab_mcp_tools` to discover tool names. | `tool_name`, `arguments?` (object) |
+| `list_jira_mcp_tools` | List all tools exposed by the Jira MCP. | — |
+| `list_gitlab_mcp_tools` | List all tools exposed by the GitLab MCP. | — |
+
+### Role-aware tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `show_roles` | List Relay persona roles (Engineer, Analyst, Scientist, Manager, Product/Process). | — |
+| `get_guidance` | Get guidance for a role: needs, suggested Relay + MCP tools, example prompts. | `role` (engineer \| analyst \| scientist \| manager \| product_process) |
+| `role_aware_checkin` | Status check with role-specific emphasis and suggested focus. | `role`, `dev_name?` |
+| `suggest_next` | Suggest next actions for the role (handoffs, start task, GitLab, etc.) using Relay and MCP. | `role`, `context?`, `dev_name?` |
+
+### Session and handoff queries
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `active_tasks` | Return current work session for the developer. | `dev_name?` |
+| `pending_handoffs` | Return handoffs waiting for the developer. | `dev_name?` |
+| `show_metrics` | Session and handoff counts for the developer. | `dev_name?` |
+
+### Intelligent orchestration tools
+
+These tools use Jira, GitLab, and/or SQLite MCPs to support handoffs, code review, sprint planning, quality, deployment, metrics, onboarding, and security. Parameters are typically `dev_name?` or tool-specific; see the MCP server schema for full input definitions.
+
+| Category | Tools |
+|----------|--------|
+| **Handoffs** | `cross_timezone_relay`, `knowledge_transfer` |
+| **Code review** | `auto_review_assignment`, `review_bottleneck_detector`, `review_impact_analyzer` |
+| **Work sessions** | `work_session_analytics`, `focus_time_protector` |
+| **Sprint planning** | `sprint_auto_planning`, `capacity_forecasting`, `story_breakdown_assistant` |
+| **Quality** | `technical_debt_tracker`, `code_quality_gate`, `flaky_test_detective` |
+| **Coordination** | `merge_conflict_predictor`, `pair_programming_matcher`, `blockers_resolver` |
+| **Deployment** | `pre_deploy_checklist`, `deploy_impact_analyzer`, `rollback_recommender` |
+| **Metrics** | `developer_happiness_tracker`, `story_cycle_time_analyzer`, `team_velocity_dashboard` |
+| **Onboarding** | `new_developer_guide`, `code_area_mapper`, `best_practices_enforcer` |
+| **Optimization** | `interruption_minimizer`, `task_switcher`, `work_life_balance_monitor` |
+| **AI-driven** | `smart_task_recommender`, `code_pattern_learner`, `sprint_risk_predictor`, `automated_retrospective` |
+| **Security** | `security_review_trigger`, `compliance_checker`, `dependency_vulnerability_scanner` |
+
+Use `list_jira_mcp_tools` and `list_gitlab_mcp_tools` to discover Jira/GitLab tool names, then call them via `query_jira` or `query_gitlab`.
+
+### Combined Jira + GitLab workflows
+
+Relay combines both MCPs in two flows:
+
+1. **Before handover — MR link in Jira:** When creating a handoff (`handoff_task` / `transfer_to`), pass `merge_request_url` (and optionally `jira_issue_key`; otherwise the active session’s Jira issue is used). Relay adds a comment on the Jira issue with the MR link and “Handoff: …” text, then creates the handoff so reviewers see the MR in Jira.
+2. **Review comments → sub-task:** Use `create_subtask_from_mr_review` with the parent Jira issue key and GitLab MR identifiers (`project_id`/`project_name`, `mr_iid`). Relay checks the MR for notes/discussions via GitLab MCP; if there are review comments, it creates a Jira sub-task (e.g. “Address MR review feedback”) under the parent so the assignee can track follow-up work. If no comments are found, no sub-task is created.
+3. **Smart handoff:** `smart_handoff` combines the above: it finds the GitLab MR for the task (optional `project_id` or `RELAY_GITLAB_PROJECT`), analyzes MR notes with a rule-based extractor, creates one Jira sub-task per required change, adds a handoff comment to Jira, and creates the handoff record. Use when handing off with full review context.
+4. **Review readiness:** `review_readiness_check` gates “ready for review” by checking Jira sub-tasks complete, GitLab pipeline and conflicts, and work session state; it returns a clear list of blockers or suggests requesting reviewers.
+5. **Context resurrection:** `context_resurrection` helps after time away by summarizing the last ended work session, Jira updates, and GitLab conflicts, with “where you left off” and next steps.
 
 ### Role-aware workflows
 

--- a/docs/jira-state-awareness.md
+++ b/docs/jira-state-awareness.md
@@ -1,0 +1,96 @@
+# Jira State Awareness (CRITICAL)
+
+**Principle:** Every orchestration tool MUST be aware of Jira task state.
+
+All 38 intelligent orchestration tools must:
+
+1. **Query Jira for current state** before taking action  
+2. **Validate state transitions** are legal  
+3. **Auto-detect context** instead of relying on user memory  
+4. **Sync local and Jira state** automatically  
+
+---
+
+## Implementation
+
+### 1. Jira state layer (`lib/jira-state.ts`)
+
+- **`getJiraState(mcp, issueKey)`** — Fetch current issue state (status, statusCategory, assignee, subtasks). Returns `null` if issue not found or Jira unavailable.
+- **`resolveTaskContext(mcp, db, developerId, taskId?)`** — Resolve task: use `task_id` if provided, else **auto-detect** from developer’s active session. Do not rely on user memory.
+- **`validateTransition(currentState, intent, targetStatus?)`** — Check that a transition is legal (e.g. don’t “start” an issue already Done). Intents: `start` | `complete` | `block` | `unblock` | `code_review`.
+- **`syncLocalStateWithJira(db, issueKey, jiraState, developerId)`** — After actions, sync local state (e.g. if Jira is Done but active session exists, suggest `complete_task` or `end_session`).
+
+### 2. WorkflowManager (orchestration)
+
+WorkflowManager exposes the same operations for use inside flows:
+
+- **`getJiraState(issueKey)`**
+- **`resolveTaskContext(developerId, taskId?)`**
+- **`validateTransition(currentState, intent, targetStatus?)`**
+- **`syncLocalStateWithJira(issueKey, jiraState, developerId)`**
+
+Existing flows (**smart_handoff**, **review_readiness_check**, **context_resurrection**) use these: they query Jira first, validate where needed, and sync at the end.
+
+### 3. BaseOrchestrationTool (`lib/base-orchestration-tool.ts`)
+
+For **new** tools (e.g. the remaining 35), extend `BaseOrchestrationTool<TPayload, TResult>`:
+
+```typescript
+import { BaseOrchestrationTool } from "../../lib/base-orchestration-tool.js";
+import type { WorkflowManager } from "../../workflow-manager.js";
+import type { JiraIssueState } from "../../types/orchestration-tools.js";
+
+export class MyNewTool extends BaseOrchestrationTool<MyParams, MyResult> {
+  constructor(wm: WorkflowManager) {
+    super(wm);
+  }
+
+  async execute(params: MyParams): Promise<MyResult> {
+    // 1. Resolve context (auto-detect task from session if not provided)
+    const ctx = await this.ensureContext(params.dev_name, params.task_id);
+    const { issueKey, state } = ctx;
+
+    // 2. Validate transition before acting
+    const validation = this.validateTransition(state, "start");
+    if (!validation.valid) {
+      return { summary: validation.error!, actions_taken: [], next_steps: [validation.suggestion!], data: {} };
+    }
+
+    // 3. … do work using state …
+
+    // 4. Sync local state with Jira after actions
+    await this.syncLocalState(issueKey, state, params.dev_name);
+
+    return { summary: "…", actions_taken: [], next_steps: [], data: {} };
+  }
+}
+```
+
+**Protected helpers on the base:**
+
+- **`getJiraState(issueKey)`** — Query current state  
+- **`resolveContext(developerId, taskId?)`** — Resolve task (with auto-detect)  
+- **`ensureJiraState(issueKey)`** — Get state or throw  
+- **`ensureContext(developerId, taskId?)`** — Get resolved context or throw  
+- **`validateTransition(state, intent, targetStatus?)`** — Check transition  
+- **`validateOrAppendWarning(state, intent, warnings, targetStatus?)`** — Validate and append to `warnings[]`  
+- **`syncLocalState(issueKey, jiraState, developerId)`** — Sync after actions  
+
+### 4. Types (`types/orchestration-tools.ts`)
+
+- **`JiraIssueState`** — `key`, `summary`, `statusName`, `statusCategory`, `assigneeId`, `assigneeName`, `subtasks`, `updated`  
+- **`ResolvedTaskContext`** — `issueKey`, `state`, `fromSession`, `sessionId`  
+- **`StateValidationResult`** — `valid`, `error?`, `suggestion?`  
+- **`JiraTransitionIntent`** — `"start" | "complete" | "block" | "unblock" | "code_review"`  
+
+---
+
+## Current tools using Jira state awareness
+
+| Tool                     | Query Jira first | Validate transition | Sync after |
+|--------------------------|------------------|----------------------|------------|
+| **smart_handoff**        | ✅ getJiraState  | ✅ (Done → handoff) | ✅ syncLocalStateWithJira |
+| **review_readiness_check** | ✅ getJiraState  | ✅ (Done → “no review”) | N/A (read-only) |
+| **context_resurrection** | ✅ getJiraState  | N/A                  | N/A (read-only) |
+
+All future orchestration tools should follow the same pattern (query → validate → act → sync).

--- a/docs/mvp-orchestration-tools.md
+++ b/docs/mvp-orchestration-tools.md
@@ -1,0 +1,113 @@
+# MVP: Top 5 Relay Orchestration Tools
+
+Recommendation for the **first 3–5 tools** to prioritize, based on existing Relay code, MCP coverage (Jira + GitLab + SQLite), and impact vs effort.
+
+---
+
+## Recommended MVP (in order)
+
+### 1. **Smart Handoff** — *Complete the flow*
+
+**Why first:** You already have ~80% of it. `handoff_task` adds MR comment and creates the handoff; `create_subtask_from_mr_review` creates Jira sub-tasks from MR notes. What’s missing is **one orchestrated flow** that:
+
+1. Resolve MR for the current task (e.g. GitLab `list_merge_requests` by branch or issue key in title).
+2. Optionally call `create_subtask_from_mr_review` if there are review comments.
+3. Call `createHandoff` with `merge_request_url` and `jira_issue_key` (from active session).
+
+**Value:** Full context transfer with zero manual steps.  
+**Effort:** Low–Medium (one new tool that chains existing APIs; MR discovery may need GitLab MCP args for project/filter).
+
+**Existing code:** `create-handoff.ts`, `create-subtask-from-mr-review.ts`, `workflow-manager.ts` (`createHandoff`, `addMrCommentToJira`, `createSubtaskFromMrReview`).
+
+---
+
+### 2. **Review Readiness Check**
+
+**Flow:** User says “Ready for review on PROJ-42” → Relay:
+
+1. **GitLab:** MR for branch/issue — state (open/mergeable), pipeline status, conflicts.
+2. **Jira:** Issue PROJ-42 — sub-tasks all done? (via Jira MCP get issue/subtasks).
+3. **SQLite:** Active session for dev — complete or hand off before “ready for review”?
+
+If all pass → “Ready. Consider requesting reviewers.” and optionally add Jira comment. If not → return a short list of blockers (e.g. “Pipeline failing”, “2 sub-tasks incomplete”, “Active session not closed”).
+
+**Value:** Stops premature “ready for review” and keeps Jira/GitLab in sync.  
+**Effort:** Low (all data available via existing MCPs; one new tool + small WorkflowManager helper).
+
+---
+
+### 3. **Context Resurrection**
+
+**Flow:** Dev returns after 3+ days → Relay:
+
+1. **SQLite:** Last work session (by `developer_id`, `ended_at` / `started_at`).
+2. **Jira:** Updates on that issue since last session (e.g. comments, status change) — Jira MCP get issue or search.
+3. **GitLab:** Branch still exists? Any MRs? Conflicts? (Git/GitLab MCP status + list MRs).
+
+Summarize: “You left off at X (issue, branch). Since then: Jira Y, GitLab Z. Conflicts / MR link: …”
+
+**Value:** Instant context recovery; no digging through Jira/GitLab.  
+**Effort:** Low. You have `getActiveSession`, `getTaskStatus`, `morningCheckin`; need “last ended session” query in `McpDbAdapter` and one new tool that composes Jira + GitLab + that session.
+
+---
+
+### 4. **Blockers Resolver**
+
+**Flow:** Dev marks task blocked (e.g. “Waiting for API key”) → Relay:
+
+1. **Jira:** Transition issue to “Blocked” (or add label) and add comment with blocker reason.
+2. **Jira:** Create a small “Unblock: PROJ-42 – API key” task and assign to whoever can fix (e.g. ops, tech lead) — or assign to a default “unblock” assignee.
+3. **SQLite:** Log blocker on the work session (e.g. new progress log type or reuse `progress_logs.note`).
+
+**Value:** Clear ownership of unblocking and visibility in Jira.  
+**Effort:** Low. Jira MCP: transition + create_issue + (if available) assign. One new tool + optional DB log.
+
+---
+
+### 5. **Pre-Deploy Checklist**
+
+**Flow:** Before deploy → Relay:
+
+1. **Jira:** Stories in scope (e.g. sprint or filter) — all “Done”?
+2. **GitLab:** MRs for release branch merged? Pipeline green?
+3. **SQLite:** No active work sessions for those issues (or warn).
+
+If any check fails → list blockers. If all pass → “Pre-deploy checks passed.”
+
+**Value:** Avoids deploying with open work or failing pipelines.  
+**Effort:** Low. Read-only checks across three MCPs; one new tool.
+
+---
+
+## Why these 5?
+
+| Tool                    | Builds on existing?        | Value              | Effort  |
+|-------------------------|----------------------------|--------------------|---------|
+| Smart Handoff           | Yes (handoff + MR + subtask) | Very high          | Low–Med |
+| Review Readiness Check  | Yes (checkin, Jira, Git)   | High               | Low     |
+| Context Resurrection    | Yes (sessions, Jira, Git)  | High               | Low     |
+| Blockers Resolver       | Yes (Jira, sessions)       | High               | Low     |
+| Pre-Deploy Checklist    | Yes (Jira, GitLab, SQLite) | Medium (safety)    | Low     |
+
+Together they cover: **handoffs**, **reviews**, **return-to-work**, **blockers**, and **deploy safety** with minimal new surface area.
+
+---
+
+## What to build first (suggested order)
+
+1. **Smart Handoff** — One “smart handoff” tool that finds MR → (optional) subtasks from review → Jira comment → handoff. Ship as the flagship orchestration.
+2. **Review Readiness Check** — Single tool: “ready for review PROJ-42” → gates + blocker list.
+3. **Context Resurrection** — “Resurrect my context” using last session + Jira + GitLab.
+4. **Blockers Resolver** — “Mark PROJ-42 blocked: waiting for API key” → Jira + optional SQLite.
+5. **Pre-Deploy Checklist** — “Pre-deploy check” for a given release/sprint.
+
+---
+
+## Out of scope for MVP (do later)
+
+- **Auto-Review Assignment** (needs “who touched these files” from GitLab + SQLite or Jira).
+- **Sprint Auto-Planning / Capacity / Risk** (more product and data model work).
+- **Technical Debt Tracker** (needs repo scan + Jira create; good Phase 2).
+- **Merge Conflict Predictor** (needs file-level or branch awareness; more GitLab API).
+
+These stay on the roadmap for Phase 2–4 after the five above are in use.

--- a/packages/core/src/flows/orchestration-flows.ts
+++ b/packages/core/src/flows/orchestration-flows.ts
@@ -1,0 +1,501 @@
+/**
+ * Orchestration flow implementations for tools 2–3, 5–7, 9–38.
+ * Each flow uses orchestrator (wm, db, Jira/GitLab MCP) and returns a result object.
+ */
+
+import type { RelayOrchestrator } from "../orchestrator.js";
+
+const defaultDev = () => process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default";
+const projectId = () => process.env["RELAY_GITLAB_PROJECT"] ?? "";
+
+// --- 2. Cross-Timezone Relay ---
+export async function crossTimezoneRelay(
+  orc: RelayOrchestrator,
+  params: { dev_name?: string; suggest_only?: boolean }
+): Promise<{ summary: string; suggested_handoff_to?: string; handoff_id?: string; next_steps: string[] }> {
+  const devId = params.dev_name ?? defaultDev();
+  const wm = orc.getWorkflowManager();
+  const db = orc.getDb();
+  const session = await db.getActiveSession(devId);
+  const received = await db.getPendingHandoffs(devId);
+  const developers = new Set<string>();
+  received.forEach((h) => developers.add(h.from_developer_id));
+  const suggested = Array.from(developers).filter((d) => d !== devId)[0] ?? "team-lead";
+  if (!session?.jira_issue_key) {
+    return { summary: "No active session to relay.", next_steps: ["Start a task first or use handoff_task with a specific issue."] };
+  }
+  if (params.suggest_only) {
+    return { summary: "Suggested next developer (by recent handoffs): " + suggested, suggested_handoff_to: suggested, next_steps: ["Use handoff_task or smart_handoff to complete relay."] };
+  }
+  return { summary: "Use smart_handoff or handoff_task to relay. Suggested recipient: " + suggested, suggested_handoff_to: suggested, next_steps: ["Call handoff_task with to_developer_id = " + suggested] };
+}
+
+// --- 3. Knowledge Transfer ---
+export async function knowledgeTransfer(
+  orc: RelayOrchestrator,
+  params: { task_id: string; dev_name?: string }
+): Promise<{ summary: string; related_tasks: string[]; handoff_history: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, related_tasks: [], handoff_history: [], next_steps: [] };
+  const projectKey = params.task_id.split("-")[0];
+  const related = await wm.searchJira(`project = ${projectKey} AND text ~ "${projectKey}" ORDER BY updated DESC`, 10);
+  const relatedKeys = related.filter((r) => r.key !== params.task_id).map((r) => `${r.key}: ${r.summary}`);
+  const db = orc.getDb();
+  const sessions = await db.getLastEndedSessions(params.dev_name ?? defaultDev(), 20);
+  const handoffHistory = sessions.filter((s) => s.jira_issue_key === params.task_id).map((s) => `Session ${s.id} (${s.ended_at})`);
+  return {
+    summary: `Knowledge transfer package for ${params.task_id}.`,
+    related_tasks: relatedKeys,
+    handoff_history: handoffHistory,
+    next_steps: ["Review related tasks in Jira", "Check GitLab for commits/MRs with " + params.task_id],
+  };
+}
+
+// --- 5. Auto-Review Assignment ---
+export async function autoReviewAssignment(
+  orc: RelayOrchestrator,
+  params: { task_id?: string; dev_name?: string }
+): Promise<{ summary: string; suggested_reviewers: string[]; mr_url?: string; next_steps: string[] }> {
+  const devId = params.dev_name ?? defaultDev();
+  const wm = orc.getWorkflowManager();
+  const db = orc.getDb();
+  const session = await db.getActiveSession(devId);
+  const issueKey = params.task_id ?? session?.jira_issue_key;
+  if (!issueKey) return { summary: "No task in context. Provide task_id or start a task.", suggested_reviewers: [], next_steps: [] };
+  const proj = projectId();
+  const mrs = proj ? await wm.listMergeRequests(proj, "opened", 20) : [];
+  const taskIdUpper = issueKey.toUpperCase();
+  const mr = mrs.find((m) => m.title.toUpperCase().includes(taskIdUpper) || m.source_branch.toUpperCase().includes(taskIdUpper)) ?? mrs[0];
+  const handoffs = await db.getPendingHandoffs(devId);
+  const reviewers = [...new Set(handoffs.map((h) => h.from_developer_id).filter(Boolean))].slice(0, 2);
+  return {
+    summary: reviewers.length ? `Suggested reviewers: ${reviewers.join(", ")}` : "Suggest requesting review from team members (use query_gitlab to assign).",
+    suggested_reviewers: reviewers,
+    mr_url: mr?.web_url,
+    next_steps: ["Request review on the MR", "Add reviewers in GitLab"],
+  };
+}
+
+// --- 6. Review Bottleneck Detector ---
+export async function reviewBottleneckDetector(orc: RelayOrchestrator): Promise<{ summary: string; overdue_mrs: Array<{ iid: number; title: string; days_waiting: number }>; next_steps: string[] }> {
+  const proj = projectId();
+  if (!proj) return { summary: "Set RELAY_GITLAB_PROJECT to scan MRs.", overdue_mrs: [], next_steps: [] };
+  const wm = orc.getWorkflowManager();
+  const mrs = await wm.listMergeRequests(proj, "opened", 50);
+  const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000;
+  const overdue = mrs
+    .filter((m) => new Date(m.updated_at).getTime() < threeDaysAgo)
+    .map((m) => ({ iid: m.iid, title: m.title, days_waiting: Math.floor((Date.now() - new Date(m.updated_at).getTime()) / (24 * 60 * 60 * 1000)) }));
+  return {
+    summary: overdue.length ? `${overdue.length} MR(s) waiting >3 days for review` : "No MRs waiting >3 days.",
+    overdue_mrs: overdue.slice(0, 10),
+    next_steps: overdue.length ? ["Create follow-up tasks in Jira", "Ping reviewers"] : [],
+  };
+}
+
+// --- 7. Review Impact Analyzer ---
+export async function reviewImpactAnalyzer(
+  orc: RelayOrchestrator,
+  params: { task_id: string; project_id?: string; mr_iid?: number }
+): Promise<{ summary: string; total_comments: number; estimated_minutes: number; suggested_story_points?: number; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, total_comments: 0, estimated_minutes: 0, next_steps: [] };
+  const proj = params.project_id ?? projectId();
+  let totalComments = 0;
+  let estimatedMinutes = 0;
+  if (proj) {
+    const mrs = await wm.listMergeRequests(proj, "opened", 10);
+    const mr = params.mr_iid ? mrs.find((m) => m.iid === params.mr_iid) : mrs.find((m) => m.title.toUpperCase().includes(params.task_id.toUpperCase()));
+    if (mr) {
+      const notes = await wm.getMergeRequestNotes(proj, mr.iid);
+      totalComments = notes.length;
+      estimatedMinutes = totalComments * 15;
+    }
+  }
+  const suggestedPoints = totalComments > 5 ? 3 : totalComments > 2 ? 2 : undefined;
+  return {
+    summary: `Review impact: ${totalComments} comment(s), ~${estimatedMinutes} min effort.`,
+    total_comments: totalComments,
+    estimated_minutes: estimatedMinutes,
+    suggested_story_points: suggestedPoints,
+    next_steps: suggestedPoints ? ["Consider updating story points in Jira"] : [],
+  };
+}
+
+// --- 9. Work Session Analytics ---
+export async function workSessionAnalytics(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; total_sessions: number; total_minutes: number; by_status: Record<string, number>; next_steps: string[] }> {
+  const db = orc.getDb();
+  const devId = params.dev_name ?? defaultDev();
+  const sessions = await db.getWorkSessionsForDeveloper(devId, 50);
+  const totalMinutes = sessions.reduce((s, x) => s + (x.total_minutes ?? 0), 0);
+  const byStatus: Record<string, number> = {};
+  sessions.forEach((x) => { byStatus[x.status] = (byStatus[x.status] ?? 0) + 1; });
+  return {
+    summary: `${sessions.length} sessions, ${totalMinutes} min logged.`,
+    total_sessions: sessions.length,
+    total_minutes: totalMinutes,
+    by_status: byStatus,
+    next_steps: ["Use focus time during your most active hours", "Consider batching similar tasks"],
+  };
+}
+
+// --- 10. Focus Time Protector ---
+export async function focusTimeProtector(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; focus_mode: boolean; session_id?: string; next_steps: string[] }> {
+  const db = orc.getDb();
+  const session = await db.getActiveSession(params.dev_name ?? defaultDev());
+  const focusMode = session != null;
+  return {
+    summary: focusMode ? "Focus mode on — you have an active session. Batch non-urgent updates until you complete or hand off." : "No active session. Start a task to enable focus mode.",
+    focus_mode: focusMode,
+    session_id: session?.id,
+    next_steps: focusMode ? ["Complete or hand off when ready", "Notifications can be batched"] : ["Start a task to enable focus mode"],
+  };
+}
+
+// --- 11. Sprint Auto-Planning ---
+export async function sprintAutoPlanning(orc: RelayOrchestrator, params: { sprint_id?: string; project_key?: string }): Promise<{ summary: string; suggested_assignments: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const backlog = await wm.searchJira(`project = ${key} AND status in (Backlog, "To Do") ORDER BY priority DESC`, 20);
+  return {
+    summary: `${backlog.length} issue(s) in backlog. Use Jira board to assign by capacity and expertise.`,
+    suggested_assignments: backlog.slice(0, 5).map((b) => b.key),
+    next_steps: ["Open Jira sprint board", "Assign by team capacity"],
+  };
+}
+
+// --- 12. Capacity Forecasting ---
+export async function capacityForecasting(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; assigned_count: number; session_hours: number; alert?: string; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const db = orc.getDb();
+  const devId = params.dev_name ?? defaultDev();
+  const assigned = await wm.searchJira(`assignee = currentUser() AND status != Done`, 50);
+  const sessions = await db.getWorkSessionsForDeveloper(devId, 20);
+  const sessionHours = sessions.reduce((s, x) => s + (x.total_minutes ?? 0) / 60, 0);
+  const alert = assigned.length > 10 ? "High assignment count — consider rebalancing." : undefined;
+  return {
+    summary: `${assigned.length} assigned, ~${sessionHours.toFixed(1)} h in recent sessions.`,
+    assigned_count: assigned.length,
+    session_hours: Math.round(sessionHours * 10) / 10,
+    alert,
+    next_steps: alert ? ["Review workload with lead"] : [],
+  };
+}
+
+// --- 13. Story Breakdown Assistant ---
+export async function storyBreakdownAssistant(orc: RelayOrchestrator, params: { task_id: string }): Promise<{ summary: string; suggested_subtasks: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, suggested_subtasks: [], next_steps: [] };
+  const suggested = ["Implement core logic", "Add tests", "Update documentation"];
+  return {
+    summary: `Suggested breakdown for ${params.task_id}: ${suggested.join("; ")}.`,
+    suggested_subtasks: suggested,
+    next_steps: ["Create sub-tasks in Jira", "Estimate each sub-task"],
+  };
+}
+
+// --- 14. Technical Debt Tracker ---
+export async function technicalDebtTracker(orc: RelayOrchestrator): Promise<{ summary: string; created_count: number; next_steps: string[] }> {
+  return {
+    summary: "Scan repo for TODO/FIXME/HACK (e.g. grep or GitLab file search), then create Jira tech-debt issues per finding.",
+    created_count: 0,
+    next_steps: ["Use query_gitlab or local grep for TODO|FIXME|HACK", "Create Jira issues and link to file:line"],
+  };
+}
+
+// --- 15. Code Quality Gate ---
+export async function codeQualityGate(orc: RelayOrchestrator, params: { task_id: string; dev_name?: string }): Promise<{ summary: string; passed: boolean; blockers: string[]; next_steps: string[] }> {
+  const result = await orc.getWorkflowManager().reviewReadinessCheck(params.task_id, params.dev_name);
+  const passed = result.data.blockers?.length === 0 && result.data.readiness.all_subtasks_complete !== false && result.data.readiness.no_conflicts !== false;
+  return {
+    summary: passed ? "Quality gate passed." : "Quality gate not passed.",
+    passed,
+    blockers: result.data.blockers?.map((b) => b.message ?? b.type) ?? [],
+    next_steps: result.next_steps,
+  };
+}
+
+// --- 16. Flaky Test Detective ---
+export async function flakyTestDetector(orc: RelayOrchestrator): Promise<{ summary: string; next_steps: string[] }> {
+  return {
+    summary: "Integrate with CI to track intermittent failures. Use pipeline failure history and create Jira issues for flaky tests.",
+    next_steps: ["Use query_gitlab list_pipelines / list_jobs for failure data", "Create Jira issues for recurring failures"],
+  };
+}
+
+// --- 17. Merge Conflict Predictor ---
+export async function mergeConflictPredictor(orc: RelayOrchestrator, params: { task_id: string; dev_name?: string }): Promise<{ summary: string; conflict_risk: string; overlapping: string[]; next_steps: string[] }> {
+  const db = orc.getDb();
+  const devId = params.dev_name ?? defaultDev();
+  const session = await db.getActiveSession(devId);
+  const others = await db.getWorkSessionsForDeveloper(devId, 1);
+  return {
+    summary: "Check GitLab for branches touching same files. Coordinate with other assignees on the project.",
+    conflict_risk: "unknown",
+    overlapping: [],
+    next_steps: ["Use query_gitlab list_merge_requests to see open MRs", "Coordinate with team on same files"],
+  };
+}
+
+// --- 18. Pair Programming Matcher ---
+export async function pairProgrammingMatcher(orc: RelayOrchestrator, params: { task_id: string }): Promise<{ summary: string; suggested_pair?: string; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, next_steps: [] };
+  const db = orc.getDb();
+  const handoffs = await db.getPendingHandoffs(state.assigneeName ?? "");
+  const from = handoffs.map((h) => h.from_developer_id)[0];
+  return {
+    summary: from ? `Suggested pair (recent handoff from): ${from}` : "Use Jira assignees or team list to find a pair.",
+    suggested_pair: from,
+    next_steps: ["Coordinate with suggested developer"],
+  };
+}
+
+// --- 19. Blockers Resolver ---
+export async function blockersResolver(orc: RelayOrchestrator, params: { task_id: string; blocker_reason?: string }): Promise<{ summary: string; unblock_task_created: boolean; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, unblock_task_created: false, next_steps: [] };
+  const projectKey = params.task_id.split("-")[0];
+  const jiraRes = await orc.callJiraMcpTool("create_issue", {
+    project: projectKey,
+    summary: `Unblock ${params.task_id}: ${params.blocker_reason ?? "blocker"}`,
+    description: `Parent: ${params.task_id}. ${params.blocker_reason ?? ""}`,
+    issuetype: "Task",
+    issueType: "Task",
+    type: "Task",
+  });
+  const created = !jiraRes.isError;
+  return {
+    summary: created ? "Unblock task created in Jira. Assign to ops/lead." : "Could not create unblock task: " + (jiraRes.content || "unknown"),
+    unblock_task_created: created,
+    next_steps: created ? ["Assign unblock task", "Link to parent"] : ["Create task manually in Jira"],
+  };
+}
+
+// --- 20. Pre-Deploy Checklist ---
+export async function preDeployChecklist(orc: RelayOrchestrator, params: { project_key?: string }): Promise<{ summary: string; ready: boolean; blockers: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const notDone = await wm.searchJira(`project = ${key} AND status != Done AND status != Closed`, 20);
+  const proj = projectId();
+  const mrs = proj ? await wm.listMergeRequests(proj, "opened", 5) : [];
+  const blockers: string[] = [];
+  if (notDone.length) blockers.push(`${notDone.length} issue(s) not Done`);
+  if (mrs.length) blockers.push(`${mrs.length} MR(s) still open`);
+  const ready = blockers.length === 0;
+  return {
+    summary: ready ? "Pre-deploy check passed." : "Pre-deploy blocked.",
+    ready,
+    blockers,
+    next_steps: ready ? ["Proceed with deploy"] : ["Complete or move issues", "Merge MRs"],
+  };
+}
+
+// --- 21. Deploy Impact Analyzer ---
+export async function deployImpactAnalyzer(orc: RelayOrchestrator, params: { version?: string; project_key?: string }): Promise<{ summary: string; issues_in_scope: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const done = await wm.searchJira(`project = ${key} AND status = Done ORDER BY updated DESC`, 15);
+  return {
+    summary: `Done issues (candidate for release): ${done.length}. Generate release notes from Jira.`,
+    issues_in_scope: done.map((d) => d.key),
+    next_steps: ["Generate release notes", "Tag release in GitLab"],
+  };
+}
+
+// --- 22. Rollback Recommender ---
+export async function rollbackRecommender(orc: RelayOrchestrator): Promise<{ summary: string; next_steps: string[] }> {
+  return {
+    summary: "Link to monitoring/APM to detect error spikes. If rollback needed, identify last deploy and revert.",
+    next_steps: ["Check GitLab pipeline for last successful deploy", "Use query_gitlab for commit history"],
+  };
+}
+
+// --- 23. Developer Happiness Tracker ---
+export async function developerHappinessTracker(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; signals: string[]; next_steps: string[] }> {
+  const db = orc.getDb();
+  const sessions = await db.getWorkSessionsForDeveloper(params.dev_name ?? defaultDev(), 30);
+  const longSessions = sessions.filter((s) => (s.total_minutes ?? 0) > 240);
+  const signals = [];
+  if (longSessions.length > 2) signals.push("Many long sessions (>4h)");
+  return {
+    summary: signals.length ? "Consider checking in with the developer." : "No strong signals.",
+    signals,
+    next_steps: signals.length ? ["1:1 check-in", "Review workload"] : [],
+  };
+}
+
+// --- 24. Story Cycle Time Analyzer ---
+export async function storyCycleTimeAnalyzer(orc: RelayOrchestrator, params: { project_key?: string }): Promise<{ summary: string; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const done = await wm.searchJira(`project = ${key} AND status = Done ORDER BY updated DESC`, 20);
+  return {
+    summary: `${done.length} Done issue(s). Use Jira reports or query_jira for created/updated dates to compute cycle time.`,
+    next_steps: ["Use Jira cycle time report", "Compare work time (SQLite sessions) vs calendar time"],
+  };
+}
+
+// --- 25. Team Velocity Dashboard ---
+export async function teamVelocityDashboard(orc: RelayOrchestrator, params: { project_key?: string }): Promise<{ summary: string; completed_count: number; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const done = await wm.searchJira(`project = ${key} AND status = Done ORDER BY updated DESC`, 50);
+  return {
+    summary: `${done.length} completed issue(s) in project. Use Jira velocity chart for trend.`,
+    completed_count: done.length,
+    next_steps: ["Open Jira velocity chart", "Correlate with GitLab commits"],
+  };
+}
+
+// --- 26. New Developer Guide ---
+export async function newDeveloperGuide(orc: RelayOrchestrator): Promise<{ summary: string; good_first_issues: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const issues = await wm.searchJira('labels = "good first issue" OR summary ~ "first" ORDER BY created DESC', 10);
+  return {
+    summary: `${issues.length} potential good-first issue(s). Review and assign.`,
+    good_first_issues: issues.map((i) => i.key + ": " + i.summary),
+    next_steps: ["Assign good-first issues", "Point to README and docs"],
+  };
+}
+
+// --- 27. Code Area Mapper ---
+export async function codeAreaMapper(orc: RelayOrchestrator, params: { task_id: string; area?: string }): Promise<{ summary: string; owners?: string[]; related_stories: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const state = await wm.getJiraState(params.task_id);
+  if (!state) return { summary: `Issue ${params.task_id} not found.`, related_stories: [], next_steps: [] };
+  const projectKey = params.task_id.split("-")[0];
+  const related = await wm.searchJira(`project = ${projectKey} ORDER BY updated DESC`, 5);
+  return {
+    summary: "Use GitLab blame/file history for code ownership. Related stories from Jira.",
+    related_stories: related.map((r) => r.key),
+    next_steps: ["Use query_gitlab for file list", "Pair with code owner"],
+  };
+}
+
+// --- 28. Best Practices Enforcer ---
+export async function bestPracticesEnforcer(orc: RelayOrchestrator, params: { task_id: string }): Promise<{ summary: string; gaps: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  await wm.getJiraState(params.task_id);
+  return {
+    summary: "Check MR description for tests/docs. Add sub-tasks if missing.",
+    gaps: ["Verify tests added", "Verify docs updated"],
+    next_steps: ["Add sub-tasks in Jira if standards not met"],
+  };
+}
+
+// --- 29. Interruption Minimizer ---
+export async function interruptionMinimizer(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; next_steps: string[] }> {
+  const db = orc.getDb();
+  const session = await db.getActiveSession(params.dev_name ?? defaultDev());
+  return {
+    summary: session ? "Active session — batch non-urgent notifications and use focus time." : "No active session.",
+    next_steps: ["Block focus time on calendar", "Batch Slack/email outside focus"],
+  };
+}
+
+// --- 30. Task Switcher ---
+export async function taskSwitcher(orc: RelayOrchestrator, params: { new_task_id: string; dev_name?: string }): Promise<{ summary: string; previous_task?: string; next_steps: string[] }> {
+  const db = orc.getDb();
+  const session = await db.getActiveSession(params.dev_name ?? defaultDev());
+  const previousTask = session?.jira_issue_key ?? undefined;
+  return {
+    summary: previousTask ? `Switching from ${previousTask} to ${params.new_task_id}. Use start_task for the new task; hand off or complete the previous one.` : `Start ${params.new_task_id} with start_task.`,
+    previous_task: previousTask ?? undefined,
+    next_steps: ["complete_task or handoff_task for current", "start_task for " + params.new_task_id],
+  };
+}
+
+// --- 31. Work-Life Balance Monitor ---
+export async function workLifeBalanceMonitor(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; hours_this_week: number; alert?: string; next_steps: string[] }> {
+  const db = orc.getDb();
+  const sessions = await db.getWorkSessionsForDeveloper(params.dev_name ?? defaultDev(), 30);
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thisWeek = sessions.filter((s) => s.started_at >= oneWeekAgo);
+  const hours = thisWeek.reduce((s, x) => s + (x.total_minutes ?? 0) / 60, 0);
+  const alert = hours > 50 ? "Over 50 hours this week — consider rebalancing." : undefined;
+  return {
+    summary: `~${hours.toFixed(1)} h in the last 7 days.`,
+    hours_this_week: Math.round(hours * 10) / 10,
+    alert,
+    next_steps: alert ? ["Take breaks", "Redistribute work"] : [],
+  };
+}
+
+// --- 32. Smart Task Recommender ---
+export async function smartTaskRecommender(orc: RelayOrchestrator, params: { dev_name?: string }): Promise<{ summary: string; suggested_tasks: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const backlog = await wm.searchJira("assignee = currentUser() AND status in (Backlog, \"To Do\") ORDER BY priority DESC", 10);
+  return {
+    summary: backlog.length ? `Suggested: ${backlog.slice(0, 3).map((b) => b.key).join(", ")}` : "No open tasks. Pull from backlog.",
+    suggested_tasks: backlog.map((b) => b.key),
+    next_steps: ["start_task with suggested key"],
+  };
+}
+
+// --- 33. Code Pattern Learner ---
+export async function codePatternLearner(orc: RelayOrchestrator, params: { task_id?: string }): Promise<{ summary: string; next_steps: string[] }> {
+  return {
+    summary: "Review past MR comments for your common patterns. Add a pre-commit checklist from recurring feedback.",
+    next_steps: ["Use review_readiness_check before submitting", "Address recurring review comments"],
+  };
+}
+
+// --- 34. Sprint Risk Predictor ---
+export async function sprintRiskPredictor(orc: RelayOrchestrator, params: { project_key?: string }): Promise<{ summary: string; remaining_count: number; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const open = await wm.searchJira(`project = ${key} AND status != Done AND status != Closed`, 50);
+  return {
+    summary: `${open.length} issue(s) still open. Use velocity to predict completion.`,
+    remaining_count: open.length,
+    next_steps: ["Review scope", "Consider descoping or adding capacity"],
+  };
+}
+
+// --- 35. Automated Retrospective ---
+export async function automatedRetrospective(orc: RelayOrchestrator, params: { sprint_id?: string; project_key?: string }): Promise<{ summary: string; completed: number; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  const key = params.project_key ?? "PROJ";
+  const done = await wm.searchJira(`project = ${key} AND status = Done ORDER BY updated DESC`, 30);
+  return {
+    summary: `Sprint data: ${done.length} Done. Gather: What went well? What to improve?`,
+    completed: done.length,
+    next_steps: ["Run retro meeting", "Create improvement tasks in Jira"],
+  };
+}
+
+// --- 36. Security Review Trigger ---
+export async function securityReviewTrigger(orc: RelayOrchestrator, params: { task_id: string }): Promise<{ summary: string; security_required: boolean; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  await wm.getJiraState(params.task_id);
+  return {
+    summary: "If MR touches auth/payment/PII, add sub-task 'Security review' and request security team.",
+    security_required: true,
+    next_steps: ["Create Security review sub-task in Jira", "Block merge until approved"],
+  };
+}
+
+// --- 37. Compliance Checker ---
+export async function complianceChecker(orc: RelayOrchestrator, params: { task_id: string }): Promise<{ summary: string; compliance_tasks: string[]; next_steps: string[] }> {
+  const wm = orc.getWorkflowManager();
+  await wm.getJiraState(params.task_id);
+  return {
+    summary: "If PII handling changed, ensure privacy docs updated. Create compliance task if needed.",
+    compliance_tasks: ["Update privacy policy", "Data retention review"],
+    next_steps: ["Create compliance task in Jira", "Assign to legal/compliance"],
+  };
+}
+
+// --- 38. Dependency Vulnerability Scanner ---
+export async function dependencyVulnerabilityScanner(orc: RelayOrchestrator): Promise<{ summary: string; next_steps: string[] }> {
+  return {
+    summary: "Scan package.json/requirements.txt (e.g. npm audit, pip-audit). Create Jira security issues for known vulnerabilities.",
+    next_steps: ["Run npm audit or pip-audit", "Create Jira issues for high/critical"],
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,6 @@ export type { RelayOrchestratorOptions } from "./orchestrator.js";
 export { runMcpServer } from "./server.js";
 export { getRoleGuidance, listRoles, ROLE_GUIDANCE, RELAY_ROLE_IDS } from "./roles.js";
 export type { RelayRoleId, RoleGuidance } from "./roles.js";
+export { BaseOrchestrationTool } from "./lib/base-orchestration-tool.js";
+export * as JiraState from "./lib/jira-state.js";
+export type { JiraIssueState, ResolvedTaskContext, StateValidationResult, JiraTransitionIntent } from "./types/orchestration-tools.js";

--- a/packages/core/src/lib/ai-analyzer.ts
+++ b/packages/core/src/lib/ai-analyzer.ts
@@ -1,0 +1,89 @@
+/**
+ * Rule-based AI analysis for orchestration tools.
+ * Used to analyze review comments, task complexity, and conflict risk.
+ * Future: can be extended to call an LLM API for deeper analysis.
+ */
+
+import type { ReviewCommentsAnalysis, RequiredChange } from "../types/orchestration-tools.js";
+
+export interface AnalyzeReviewCommentsInput {
+  notes?: Array<{ body?: string; author?: { username?: string }; system?: boolean; resolved?: boolean }>;
+  discussions?: Array<{ notes?: Array<{ body?: string; author?: { username?: string }; resolved?: boolean }> }>;
+}
+
+/**
+ * Analyze GitLab MR notes/discussions and extract required changes (rule-based).
+ * Infers priority from language (must → high, should → medium, consider → low).
+ */
+export function analyzeReviewComments(input: AnalyzeReviewCommentsInput): ReviewCommentsAnalysis {
+  const notes: Array<{ body: string; author?: string; resolved?: boolean }> = [];
+
+  if (input.notes?.length) {
+    for (const n of input.notes) {
+      if (n.system) continue;
+      const body = typeof n.body === "string" ? n.body : "";
+      if (!body.trim()) continue;
+      notes.push({
+        body,
+        author: (n.author as any)?.username,
+        resolved: (n as any).resolved ?? false,
+      });
+    }
+  }
+
+  if (input.discussions?.length) {
+    for (const d of input.discussions) {
+      for (const n of d.notes ?? []) {
+        const body = typeof n.body === "string" ? n.body : "";
+        if (!body.trim()) continue;
+        notes.push({
+          body,
+          author: (n.author as any)?.username,
+          resolved: (n as any).resolved ?? false,
+        });
+      }
+    }
+  }
+
+  const unresolved = notes.filter((n) => !n.resolved);
+  const requiredChanges: RequiredChange[] = [];
+
+  for (const n of unresolved) {
+    const priority = inferPriority(n.body);
+    const summary = summarizeComment(n.body);
+    requiredChanges.push({
+      summary,
+      description: n.body.slice(0, 500),
+      priority,
+      estimatedMinutes: estimateMinutes(priority, n.body.length),
+      reviewerUsername: n.author,
+    });
+  }
+
+  return {
+    changesRequested: unresolved.length > 0,
+    requiredChanges,
+    unresolvedThreads: unresolved.length,
+    totalComments: notes.length,
+  };
+}
+
+function inferPriority(text: string): "high" | "medium" | "low" {
+  const t = text.toLowerCase();
+  if (/\b(must|critical|blocker|required|need to)\b/.test(t)) return "high";
+  if (/\b(should|please|recommend|better)\b/.test(t)) return "medium";
+  return "low";
+}
+
+function summarizeComment(body: string, maxLen = 80): string {
+  const firstLine = body.split(/\n/)[0]?.trim() ?? "";
+  const cleaned = firstLine.replace(/^#+\s*/, "").trim();
+  if (cleaned.length <= maxLen) return cleaned;
+  return cleaned.slice(0, maxLen - 3) + "...";
+}
+
+function estimateMinutes(priority: string, bodyLength: number): number {
+  const base = priority === "high" ? 20 : priority === "medium" ? 15 : 10;
+  const extra = Math.min(30, Math.floor(bodyLength / 50));
+  return base + extra;
+}

--- a/packages/core/src/lib/base-orchestration-tool.ts
+++ b/packages/core/src/lib/base-orchestration-tool.ts
@@ -1,0 +1,100 @@
+/**
+ * Base class for all 38 orchestration tools.
+ * CRITICAL: Every tool MUST be Jira state aware.
+ *
+ * Principle: Query Jira for current state before taking action, validate transitions,
+ * auto-detect context from session, and sync local + Jira state.
+ */
+
+import type { WorkflowManager } from "../workflow-manager.js";
+import type { JiraIssueState, ResolvedTaskContext, StateValidationResult, JiraTransitionIntent, OrchestrationResultBase } from "../types/orchestration-tools.js";
+
+export abstract class BaseOrchestrationTool<TPayload, TResult extends OrchestrationResultBase> {
+  constructor(protected wm: WorkflowManager) {}
+
+  /**
+   * Query Jira for current issue state. Call before any action.
+   * Returns null if issue not found or Jira unavailable (graceful degradation).
+   */
+  protected async getJiraState(issueKey: string): Promise<JiraIssueState | null> {
+    return this.wm.getJiraState(issueKey);
+  }
+
+  /**
+   * Resolve task context: use task_id if provided, else auto-detect from developer's active session.
+   * Do not rely on user memory — always resolve context.
+   */
+  protected async resolveContext(developerId: string, taskId?: string): Promise<ResolvedTaskContext | null> {
+    return this.wm.resolveTaskContext(developerId, taskId);
+  }
+
+  /**
+   * Validate that a state transition is legal before performing it.
+   * Returns { valid, error?, suggestion? }.
+   */
+  protected validateTransition(
+    currentState: JiraIssueState,
+    intent: JiraTransitionIntent,
+    targetStatus?: string
+  ): StateValidationResult {
+    return this.wm.validateTransition(currentState, intent, targetStatus);
+  }
+
+  /**
+   * Sync local state with Jira after actions.
+   * E.g. if Jira is Done but active session exists, returns message to suggest complete_task.
+   */
+  protected async syncLocalState(
+    issueKey: string,
+    jiraState: JiraIssueState,
+    developerId: string
+  ): Promise<{ synced: boolean; message?: string }> {
+    return this.wm.syncLocalStateWithJira(issueKey, jiraState, developerId);
+  }
+
+  /**
+   * Ensure we have Jira state for the issue; throw with clear message if not.
+   */
+  protected async ensureJiraState(issueKey: string): Promise<JiraIssueState> {
+    const state = await this.getJiraState(issueKey);
+    if (!state) {
+      throw new Error(`Jira issue ${issueKey} not found or Jira unavailable. Check the issue key and Jira MCP connection.`);
+    }
+    return state;
+  }
+
+  /**
+   * Ensure we have resolved context (issue + state). Prefer taskId if provided, else from session.
+   */
+  protected async ensureContext(developerId: string, taskId?: string): Promise<ResolvedTaskContext> {
+    const ctx = await this.resolveContext(developerId, taskId);
+    if (!ctx) {
+      if (taskId) {
+        throw new Error(`Could not resolve context for ${taskId}. Issue not found or no active session.`);
+      }
+      throw new Error("No task in progress. Provide task_id or start_task first.");
+    }
+    return ctx;
+  }
+
+  /**
+   * Validate transition; if invalid, append error to warnings and return false, else return true.
+   */
+  protected validateOrAppendWarning(
+    currentState: JiraIssueState,
+    intent: JiraTransitionIntent,
+    warnings: string[],
+    targetStatus?: string
+  ): boolean {
+    const result = this.validateTransition(currentState, intent, targetStatus);
+    if (!result.valid) {
+      warnings.push(result.error ?? "Invalid transition");
+      if (result.suggestion) warnings.push(result.suggestion);
+      return false;
+    }
+    return true;
+  }
+
+  /** Subclasses implement the orchestration. Must use getJiraState / resolveContext / validateTransition / syncLocalState as appropriate. */
+  abstract execute(params: TPayload): Promise<TResult>;
+}

--- a/packages/core/src/lib/jira-state.ts
+++ b/packages/core/src/lib/jira-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Jira state awareness: query current state, validate transitions, sync local state.
+ * Every orchestration tool MUST use this before taking action (CRITICAL requirement).
+ */
+
+import type { McpClientsManager } from "../mcp-clients.js";
+import type { IRelayDb } from "../db-adapter.js";
+import type { JiraIssueState, ResolvedTaskContext, StateValidationResult, JiraTransitionIntent } from "../types/orchestration-tools.js";
+
+const DEFAULT_DEV = (): string => process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default";
+
+/** Parse Jira get_issue response into JiraIssueState. */
+export function parseJiraIssueState(content: string): JiraIssueState | null {
+  if (!content?.trim()) return null;
+  try {
+    const data = JSON.parse(content);
+    const key = data.key ?? data.id ?? "";
+    const fields = data.fields ?? data;
+    const status = fields.status ?? data.status;
+    const statusName = status?.name ?? status?.id ?? "Unknown";
+    const statusCategory = status?.statusCategory?.key ?? status?.statusCategory?.name ?? statusName;
+    const assignee = fields.assignee ?? data.assignee;
+    const assigneeId = assignee?.accountId ?? assignee?.key ?? assignee?.name ?? null;
+    const assigneeName = assignee?.displayName ?? assignee?.name ?? null;
+    const rawSubtasks = fields.subtasks ?? data.subtasks ?? [];
+    const subtasks = rawSubtasks.map((s: any) => {
+      const f = s.fields ?? s;
+      const st = f.status ?? s.status;
+      return {
+        key: s.key ?? s.id ?? "",
+        statusName: st?.name ?? "Unknown",
+        statusCategory: st?.statusCategory?.key ?? st?.statusCategory?.name ?? "Unknown",
+      };
+    });
+    return {
+      key,
+      summary: fields.summary ?? data.summary ?? null,
+      statusName,
+      statusCategory,
+      assigneeId,
+      assigneeName,
+      subtasks,
+      updated: fields.updated ?? data.updated,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Query Jira for current issue state. Returns null if issue not found or Jira unavailable. */
+export async function getJiraState(mcp: McpClientsManager, issueKey: string): Promise<JiraIssueState | null> {
+  const getTool = await mcp.getJiraGetIssueTool();
+  const res = await mcp.callJiraTool(getTool, { issue_key: issueKey, issueKey, key: issueKey });
+  if (res.isError || !res.content) return null;
+  return parseJiraIssueState(res.content);
+}
+
+/**
+ * Resolve task context: use task_id if provided, else auto-detect from developer's active session.
+ * Every tool should call this so we don't rely on user memory.
+ */
+export async function resolveTaskContext(
+  mcp: McpClientsManager,
+  db: IRelayDb,
+  developerId: string,
+  taskId?: string
+): Promise<ResolvedTaskContext | null> {
+  const devId = developerId || DEFAULT_DEV();
+  const activeSession = await db.getActiveSession(devId);
+  const issueKey = (taskId ?? activeSession?.jira_issue_key ?? "").trim();
+  if (!issueKey) return null;
+
+  const state = await getJiraState(mcp, issueKey);
+  if (!state) return null;
+
+  const fromSession = !taskId && activeSession?.jira_issue_key === issueKey;
+  return {
+    issueKey,
+    state,
+    fromSession,
+    sessionId: fromSession ? activeSession?.id ?? null : null,
+  };
+}
+
+/**
+ * Validate that a state transition is legal before performing it.
+ * Uses common workflow rules; Jira workflow may vary by project.
+ */
+export function validateTransition(
+  currentState: JiraIssueState,
+  intent: JiraTransitionIntent,
+  _targetStatus?: string
+): StateValidationResult {
+  const cat = (currentState.statusCategory || "").toLowerCase();
+  const name = (currentState.statusName || "").toLowerCase();
+
+  switch (intent) {
+    case "start":
+      if (cat === "done" || name === "done") {
+        return { valid: false, error: "Issue is already Done.", suggestion: "Reopen or create a new task." };
+      }
+      return { valid: true };
+
+    case "complete":
+      if (cat === "done" || name === "done") {
+        return { valid: false, error: "Issue is already Done.", suggestion: "No transition needed." };
+      }
+      return { valid: true };
+
+    case "code_review":
+      if (cat === "done") {
+        return { valid: false, error: "Issue is Done; cannot move to Code Review." };
+      }
+      return { valid: true };
+
+    case "block":
+    case "unblock":
+      return { valid: true };
+
+    default:
+      return { valid: true };
+  }
+}
+
+/**
+ * Sync local state with Jira: e.g. if Jira is Done but we have an active session for that issue,
+ * we can end the session or surface a warning. Call after taking Jira actions.
+ */
+export async function syncLocalStateWithJira(
+  db: IRelayDb,
+  issueKey: string,
+  jiraState: JiraIssueState,
+  developerId: string
+): Promise<{ synced: boolean; message?: string }> {
+  const devId = developerId || DEFAULT_DEV();
+  const activeSession = await db.getActiveSession(devId);
+  if (!activeSession || activeSession.jira_issue_key !== issueKey) return { synced: true };
+
+  const cat = (jiraState.statusCategory || "").toLowerCase();
+  const name = (jiraState.statusName || "").toLowerCase();
+  if (cat === "done" || name === "done") {
+    return {
+      synced: false,
+      message: `Jira ${issueKey} is Done but you have an active session for it. Consider complete_task or end_session to sync.`,
+    };
+  }
+  return { synced: true };
+}

--- a/packages/core/src/mcp-clients.ts
+++ b/packages/core/src/mcp-clients.ts
@@ -364,6 +364,56 @@ export class McpClientsManager {
     return match?.name ?? "git_log";
   }
 
+  /** Resolve Jira MCP tool name for workflow: add comment to issue. */
+  async getJiraAddCommentTool(): Promise<string> {
+    const tools = await this.listJiraTools();
+    const match = tools.find(
+      (t) =>
+        /comment|add_comment|create_comment/i.test(t.name) ||
+        (t.description && /comment.*issue|add.*comment/i.test(t.description))
+    );
+    return match?.name ?? "add_comment";
+  }
+
+  /** Resolve Jira MCP tool name for workflow: create sub-task or create issue. */
+  async getJiraCreateIssueTool(): Promise<string> {
+    const tools = await this.listJiraTools();
+    const subtask = tools.find(
+      (t) =>
+        /subtask|sub_task|create_subtask/i.test(t.name) ||
+        (t.description && /subtask|sub-task/i.test(t.description))
+    );
+    if (subtask) return subtask.name;
+    const create = tools.find(
+      (t) =>
+        /create_issue|create_issue|createIssue/i.test(t.name) ||
+        (t.description && /create.*issue/i.test(t.description))
+    );
+    return create?.name ?? "create_issue";
+  }
+
+  /** Resolve Git/GitLab MCP tool name for workflow: list merge requests. */
+  async getGitLabMergeRequestsTool(): Promise<string> {
+    const tools = await this.listGitTools();
+    const match = tools.find(
+      (t) =>
+        /merge_request|merge request|list_mr|list_merge/i.test(t.name) ||
+        (t.description && /merge request|MR/i.test(t.description))
+    );
+    return match?.name ?? "list_merge_requests";
+  }
+
+  /** Resolve Git/GitLab MCP tool name for workflow: MR notes / review comments / discussions. */
+  async getGitLabMrNotesTool(): Promise<string> {
+    const tools = await this.listGitTools();
+    const match = tools.find(
+      (t) =>
+        /note|comment|discussion|review/i.test(t.name) ||
+        (t.description && /note|comment|discussion|review.*MR/i.test(t.description))
+    );
+    return match?.name ?? "list_merge_request_notes";
+  }
+
   async close(): Promise<void> {
     if (this.jiraTransport) await (this.jiraTransport as any).close?.();
     if (this.gitTransport) await (this.gitTransport as any).close?.();

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -56,6 +56,29 @@ export class RelayOrchestrator {
     return this.wm.createHandoff(input);
   }
 
+  /** Add MR link as comment on Jira issue (combined Jira + GitLab before handoff). */
+  async addMrCommentToJira(
+    issueKey: string,
+    mergeRequestUrl: string,
+    extraText?: string
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.wm.addMrCommentToJira(issueKey, mergeRequestUrl, extraText);
+  }
+
+  /** Create Jira sub-task from MR review comments (combined Jira + GitLab). */
+  async createSubtaskFromMrReview(
+    parentIssueKey: string,
+    options: {
+      mergeRequestUrl?: string;
+      projectId?: string;
+      projectName?: string;
+      mrIid?: number;
+      mergeRequestId?: string;
+    }
+  ): Promise<{ subtaskKey?: string; created: boolean; noteCount?: number; error?: string }> {
+    return this.wm.createSubtaskFromMrReview(parentIssueKey, options);
+  }
+
   async endOfDay(devName?: string) {
     return this.wm.endOfDay(devName);
   }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -12,6 +12,10 @@ import { startTaskTool, runStartTask } from "./tools/start-task.js";
 import { updateProgressTool, runUpdateProgress } from "./tools/update-progress.js";
 import { completeTaskTool, runCompleteTask } from "./tools/complete-task.js";
 import { createHandoffTool, runCreateHandoff } from "./tools/create-handoff.js";
+import {
+  createSubtaskFromMrReviewTool,
+  runCreateSubtaskFromMrReview,
+} from "./tools/create-subtask-from-mr-review.js";
 import { endOfDayTool, runEndOfDay } from "./tools/end-of-day.js";
 import {
   getRoleGuidanceTool,
@@ -23,6 +27,84 @@ import {
   listRolesTool,
   runListRoles,
 } from "./tools/role-tools.js";
+import {
+  smartHandoffTool,
+  runSmartHandoff,
+  reviewReadinessTool,
+  runReviewReadinessCheck,
+  contextResurrectionTool,
+  runContextResurrection,
+  crossTimezoneRelayTool,
+  runCrossTimezoneRelay,
+  knowledgeTransferTool,
+  runKnowledgeTransfer,
+  autoReviewAssignmentTool,
+  runAutoReviewAssignment,
+  reviewBottleneckDetectorTool,
+  runReviewBottleneckDetector,
+  reviewImpactAnalyzerTool,
+  runReviewImpactAnalyzer,
+  workSessionAnalyticsTool,
+  runWorkSessionAnalytics,
+  focusTimeProtectorTool,
+  runFocusTimeProtector,
+  sprintAutoPlanningTool,
+  runSprintAutoPlanning,
+  capacityForecastingTool,
+  runCapacityForecasting,
+  storyBreakdownAssistantTool,
+  runStoryBreakdownAssistant,
+  technicalDebtTrackerTool,
+  runTechnicalDebtTracker,
+  codeQualityGateTool,
+  runCodeQualityGate,
+  flakyTestDetectorTool,
+  runFlakyTestDetector,
+  mergeConflictPredictorTool,
+  runMergeConflictPredictor,
+  pairProgrammingMatcherTool,
+  runPairProgrammingMatcher,
+  blockersResolverTool,
+  runBlockersResolver,
+  preDeployChecklistTool,
+  runPreDeployChecklist,
+  deployImpactAnalyzerTool,
+  runDeployImpactAnalyzer,
+  rollbackRecommenderTool,
+  runRollbackRecommender,
+  developerHappinessTrackerTool,
+  runDeveloperHappinessTracker,
+  storyCycleTimeAnalyzerTool,
+  runStoryCycleTimeAnalyzer,
+  teamVelocityDashboardTool,
+  runTeamVelocityDashboard,
+  newDeveloperGuideTool,
+  runNewDeveloperGuide,
+  codeAreaMapperTool,
+  runCodeAreaMapper,
+  bestPracticesEnforcerTool,
+  runBestPracticesEnforcer,
+  interruptionMinimizerTool,
+  runInterruptionMinimizer,
+  taskSwitcherTool,
+  runTaskSwitcher,
+  workLifeBalanceMonitorTool,
+  runWorkLifeBalanceMonitor,
+  smartTaskRecommenderTool,
+  runSmartTaskRecommender,
+  codePatternLearnerTool,
+  runCodePatternLearner,
+  sprintRiskPredictorTool,
+  runSprintRiskPredictor,
+  automatedRetrospectiveTool,
+  runAutomatedRetrospective,
+  securityReviewTriggerTool,
+  runSecurityReviewTrigger,
+  complianceCheckerTool,
+  runComplianceChecker,
+  dependencyVulnerabilityScannerTool,
+  runDependencyVulnerabilityScanner,
+} from "./tools/index.js";
 
 const orchestrator = new RelayOrchestrator();
 
@@ -69,6 +151,45 @@ const tools = [
   { ...completeTaskTool(orchestrator as any), name: "finish_task" },
   createHandoffTool(orchestrator as any),
   { ...createHandoffTool(orchestrator as any), name: "transfer_to" },
+  createSubtaskFromMrReviewTool(),
+  smartHandoffTool(),
+  reviewReadinessTool(),
+  contextResurrectionTool(),
+  crossTimezoneRelayTool(),
+  knowledgeTransferTool(),
+  autoReviewAssignmentTool(),
+  reviewBottleneckDetectorTool(),
+  reviewImpactAnalyzerTool(),
+  workSessionAnalyticsTool(),
+  focusTimeProtectorTool(),
+  sprintAutoPlanningTool(),
+  capacityForecastingTool(),
+  storyBreakdownAssistantTool(),
+  technicalDebtTrackerTool(),
+  codeQualityGateTool(),
+  flakyTestDetectorTool(),
+  mergeConflictPredictorTool(),
+  pairProgrammingMatcherTool(),
+  blockersResolverTool(),
+  preDeployChecklistTool(),
+  deployImpactAnalyzerTool(),
+  rollbackRecommenderTool(),
+  developerHappinessTrackerTool(),
+  storyCycleTimeAnalyzerTool(),
+  teamVelocityDashboardTool(),
+  newDeveloperGuideTool(),
+  codeAreaMapperTool(),
+  bestPracticesEnforcerTool(),
+  interruptionMinimizerTool(),
+  taskSwitcherTool(),
+  workLifeBalanceMonitorTool(),
+  smartTaskRecommenderTool(),
+  codePatternLearnerTool(),
+  sprintRiskPredictorTool(),
+  automatedRetrospectiveTool(),
+  securityReviewTriggerTool(),
+  complianceCheckerTool(),
+  dependencyVulnerabilityScannerTool(),
   endSessionBase,
   { ...endSessionBase, name: "pause_session" },
   { ...endSessionBase, name: "resume_session" },
@@ -191,7 +312,156 @@ export async function runMcpServer(): Promise<void> {
           break;
         case "handoff_task":
         case "transfer_to":
-          text = await runCreateHandoff(orchestrator as any, { ...a, from_developer_id: devId } as any);
+          text = await runCreateHandoff(orchestrator.getWorkflowManager(), {
+            ...a,
+            from_developer_id: devId,
+            merge_request_url: a.merge_request_url as string | undefined,
+            jira_issue_key: a.jira_issue_key as string | undefined,
+          } as any);
+          break;
+        case "create_subtask_from_mr_review":
+          text = await runCreateSubtaskFromMrReview(orchestrator, {
+            jira_issue_key: a.jira_issue_key as string,
+            merge_request_url: a.merge_request_url as string | undefined,
+            project_id: a.project_id as string | undefined,
+            project_name: a.project_name as string | undefined,
+            mr_iid: a.mr_iid as number | undefined,
+            merge_request_id: a.merge_request_id as string | undefined,
+          });
+          break;
+        case "smart_handoff":
+          text = await runSmartHandoff(orchestrator, {
+            task_id: a.task_id as string,
+            from_dev: a.from_dev as string,
+            to_dev: a.to_dev as string,
+            auto_analyze: a.auto_analyze as boolean | undefined,
+            custom_notes: a.custom_notes as string | undefined,
+            project_id: a.project_id as string | undefined,
+            project_name: a.project_name as string | undefined,
+            merge_request_url: a.merge_request_url as string | undefined,
+            mr_iid: a.mr_iid as number | undefined,
+          });
+          break;
+        case "review_readiness_check":
+          text = await runReviewReadinessCheck(orchestrator, {
+            task_id: a.task_id as string,
+            dev_name: devId,
+          });
+          break;
+        case "context_resurrection":
+          text = await runContextResurrection(orchestrator, {
+            dev_name: devId,
+            days_away: a.days_away as number | undefined,
+          });
+          break;
+        case "cross_timezone_relay":
+          text = await runCrossTimezoneRelay(orchestrator, { dev_name: devId, suggest_only: a.suggest_only as boolean | undefined });
+          break;
+        case "knowledge_transfer":
+          text = await runKnowledgeTransfer(orchestrator, { task_id: a.task_id as string, dev_name: devId });
+          break;
+        case "auto_review_assignment":
+          text = await runAutoReviewAssignment(orchestrator, { task_id: a.task_id as string | undefined, dev_name: devId });
+          break;
+        case "review_bottleneck_detector":
+          text = await runReviewBottleneckDetector(orchestrator);
+          break;
+        case "review_impact_analyzer":
+          text = await runReviewImpactAnalyzer(orchestrator, {
+            task_id: a.task_id as string,
+            project_id: a.project_id as string | undefined,
+            mr_iid: a.mr_iid as number | undefined,
+          });
+          break;
+        case "work_session_analytics":
+          text = await runWorkSessionAnalytics(orchestrator, { dev_name: devId });
+          break;
+        case "focus_time_protector":
+          text = await runFocusTimeProtector(orchestrator, { dev_name: devId });
+          break;
+        case "sprint_auto_planning":
+          text = await runSprintAutoPlanning(orchestrator, { sprint_id: a.sprint_id as string | undefined, project_key: a.project_key as string | undefined });
+          break;
+        case "capacity_forecasting":
+          text = await runCapacityForecasting(orchestrator, { dev_name: devId });
+          break;
+        case "story_breakdown_assistant":
+          text = await runStoryBreakdownAssistant(orchestrator, { task_id: a.task_id as string });
+          break;
+        case "technical_debt_tracker":
+          text = await runTechnicalDebtTracker(orchestrator);
+          break;
+        case "code_quality_gate":
+          text = await runCodeQualityGate(orchestrator, { task_id: a.task_id as string, dev_name: devId });
+          break;
+        case "flaky_test_detective":
+          text = await runFlakyTestDetector(orchestrator);
+          break;
+        case "merge_conflict_predictor":
+          text = await runMergeConflictPredictor(orchestrator, { task_id: a.task_id as string, dev_name: devId });
+          break;
+        case "pair_programming_matcher":
+          text = await runPairProgrammingMatcher(orchestrator, { task_id: a.task_id as string });
+          break;
+        case "blockers_resolver":
+          text = await runBlockersResolver(orchestrator, { task_id: a.task_id as string, blocker_reason: a.blocker_reason as string | undefined });
+          break;
+        case "pre_deploy_checklist":
+          text = await runPreDeployChecklist(orchestrator, { project_key: a.project_key as string | undefined });
+          break;
+        case "deploy_impact_analyzer":
+          text = await runDeployImpactAnalyzer(orchestrator, { version: a.version as string | undefined, project_key: a.project_key as string | undefined });
+          break;
+        case "rollback_recommender":
+          text = await runRollbackRecommender(orchestrator);
+          break;
+        case "developer_happiness_tracker":
+          text = await runDeveloperHappinessTracker(orchestrator, { dev_name: devId });
+          break;
+        case "story_cycle_time_analyzer":
+          text = await runStoryCycleTimeAnalyzer(orchestrator, { project_key: a.project_key as string | undefined });
+          break;
+        case "team_velocity_dashboard":
+          text = await runTeamVelocityDashboard(orchestrator, { project_key: a.project_key as string | undefined });
+          break;
+        case "new_developer_guide":
+          text = await runNewDeveloperGuide(orchestrator);
+          break;
+        case "code_area_mapper":
+          text = await runCodeAreaMapper(orchestrator, { task_id: a.task_id as string, area: a.area as string | undefined });
+          break;
+        case "best_practices_enforcer":
+          text = await runBestPracticesEnforcer(orchestrator, { task_id: a.task_id as string });
+          break;
+        case "interruption_minimizer":
+          text = await runInterruptionMinimizer(orchestrator, { dev_name: devId });
+          break;
+        case "task_switcher":
+          text = await runTaskSwitcher(orchestrator, { new_task_id: a.new_task_id as string, dev_name: devId });
+          break;
+        case "work_life_balance_monitor":
+          text = await runWorkLifeBalanceMonitor(orchestrator, { dev_name: devId });
+          break;
+        case "smart_task_recommender":
+          text = await runSmartTaskRecommender(orchestrator, { dev_name: devId });
+          break;
+        case "code_pattern_learner":
+          text = await runCodePatternLearner(orchestrator, { task_id: a.task_id as string | undefined });
+          break;
+        case "sprint_risk_predictor":
+          text = await runSprintRiskPredictor(orchestrator, { project_key: a.project_key as string | undefined });
+          break;
+        case "automated_retrospective":
+          text = await runAutomatedRetrospective(orchestrator, { sprint_id: a.sprint_id as string | undefined, project_key: a.project_key as string | undefined });
+          break;
+        case "security_review_trigger":
+          text = await runSecurityReviewTrigger(orchestrator, { task_id: a.task_id as string });
+          break;
+        case "compliance_checker":
+          text = await runComplianceChecker(orchestrator, { task_id: a.task_id as string });
+          break;
+        case "dependency_vulnerability_scanner":
+          text = await runDependencyVulnerabilityScanner(orchestrator);
           break;
         case "end_session":
         case "pause_session":

--- a/packages/core/src/tools/ai-driven/auto-retrospective.ts
+++ b/packages/core/src/tools/ai-driven/auto-retrospective.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { automatedRetrospective } from "../../flows/orchestration-flows.js";
+
+export function automatedRetrospectiveTool(): Tool {
+  return {
+    name: "automated_retrospective",
+    description: "Generate retrospective: gather sprint data and AI-generated 'went well' and 'improve' insights.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sprint_id: { type: "string", description: "Sprint identifier" },
+        project_key: { type: "string", description: "Jira project key" },
+      },
+    },
+  };
+}
+
+export async function runAutomatedRetrospective(orc: RelayOrchestrator, args: { sprint_id?: string; project_key?: string }): Promise<string> {
+  const r = await automatedRetrospective(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/ai-driven/pattern-learner.ts
+++ b/packages/core/src/tools/ai-driven/pattern-learner.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { codePatternLearner } from "../../flows/orchestration-flows.js";
+
+export function codePatternLearnerTool(): Tool {
+  return {
+    name: "code_pattern_learner",
+    description: "Learn your coding patterns and suggest improvements before review. Use before submitting MR.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+    },
+  };
+}
+
+export async function runCodePatternLearner(orc: RelayOrchestrator, args: { task_id?: string }): Promise<string> {
+  const r = await codePatternLearner(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/ai-driven/risk-predictor.ts
+++ b/packages/core/src/tools/ai-driven/risk-predictor.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { sprintRiskPredictor } from "../../flows/orchestration-flows.js";
+
+export function sprintRiskPredictorTool(): Tool {
+  return {
+    name: "sprint_risk_predictor",
+    description: "Mid-sprint: predict completion probability and suggest descoping or adding capacity.",
+    inputSchema: {
+      type: "object",
+      properties: { project_key: { type: "string", description: "Jira project key" } },
+    },
+  };
+}
+
+export async function runSprintRiskPredictor(orc: RelayOrchestrator, args: { project_key?: string }): Promise<string> {
+  const r = await sprintRiskPredictor(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/ai-driven/task-recommender.ts
+++ b/packages/core/src/tools/ai-driven/task-recommender.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { smartTaskRecommender } from "../../flows/orchestration-flows.js";
+
+export function smartTaskRecommenderTool(): Tool {
+  return {
+    name: "smart_task_recommender",
+    description: "Recommend next task based on your skills and interests. Matches you to backlog items.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runSmartTaskRecommender(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await smartTaskRecommender(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_tasks.length) lines.push("", "Suggested: " + r.suggested_tasks.join(", "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/code-review/auto-review-assignment.ts
+++ b/packages/core/src/tools/code-review/auto-review-assignment.ts
@@ -1,0 +1,26 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { autoReviewAssignment } from "../../flows/orchestration-flows.js";
+
+export function autoReviewAssignmentTool(): Tool {
+  return {
+    name: "auto_review_assignment",
+    description: "Suggest and assign the best reviewers for your MR based on recent handoffs and context. Auto-detects current task if not provided.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key (optional; uses active session if omitted)" },
+        dev_name: { type: "string", description: "Developer id" },
+      },
+    },
+  };
+}
+
+export async function runAutoReviewAssignment(orc: RelayOrchestrator, args: { task_id?: string; dev_name?: string }): Promise<string> {
+  const r = await autoReviewAssignment(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_reviewers.length) lines.push("", "Suggested reviewers: " + r.suggested_reviewers.join(", "));
+  if (r.mr_url) lines.push("", "MR: " + r.mr_url);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/code-review/review-bottleneck.ts
+++ b/packages/core/src/tools/code-review/review-bottleneck.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { reviewBottleneckDetector } from "../../flows/orchestration-flows.js";
+
+export function reviewBottleneckDetectorTool(): Tool {
+  return {
+    name: "review_bottleneck_detector",
+    description: "Find MRs waiting more than 3 days for review. Creates visibility for follow-up and unblocking.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runReviewBottleneckDetector(orc: RelayOrchestrator): Promise<string> {
+  const r = await reviewBottleneckDetector(orc);
+  const lines = [r.summary];
+  if (r.overdue_mrs.length) lines.push("", "Overdue MRs:", ...r.overdue_mrs.map((m) => `- !${m.iid} ${m.title} (${m.days_waiting}d)`));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/code-review/review-impact.ts
+++ b/packages/core/src/tools/code-review/review-impact.ts
@@ -1,0 +1,27 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { reviewImpactAnalyzer } from "../../flows/orchestration-flows.js";
+
+export function reviewImpactAnalyzerTool(): Tool {
+  return {
+    name: "review_impact_analyzer",
+    description: "Analyze review comments for a task, estimate effort, and suggest story point updates if significant.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key" },
+        project_id: { type: "string", description: "GitLab project ID" },
+        mr_iid: { type: "number", description: "Merge request IID" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runReviewImpactAnalyzer(orc: RelayOrchestrator, args: { task_id: string; project_id?: string; mr_iid?: number }): Promise<string> {
+  const r = await reviewImpactAnalyzer(orc, args);
+  const lines = [r.summary, "", `Comments: ${r.total_comments}, Est. minutes: ${r.estimated_minutes}`];
+  if (r.suggested_story_points) lines.push("Suggested story points: " + r.suggested_story_points);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/code-review/review-readiness.ts
+++ b/packages/core/src/tools/code-review/review-readiness.ts
@@ -1,0 +1,59 @@
+/**
+ * Review Readiness Check — Is this task ready for code review?
+ * Category: Code Review. MCPs: Jira + GitLab + SQLite.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+
+export function reviewReadinessTool(): Tool {
+  return {
+    name: "review_readiness_check",
+    description: `Check if a task is ready for code review.
+
+I'll check:
+- Jira: Are all sub-tasks complete?
+- GitLab: Are tests passing? Any merge conflicts?
+- Your work session: Is it complete or handed off?
+
+If ready, I'll suggest next steps (e.g. request reviewers). If not, I'll list exactly what to fix.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: {
+          type: "string",
+          description: "Jira task ID (e.g. PROJ-42)",
+        },
+        dev_name: {
+          type: "string",
+          description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)",
+        },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runReviewReadinessCheck(
+  orchestrator: RelayOrchestrator,
+  args: { task_id: string; dev_name?: string }
+): Promise<string> {
+  const devId = args.dev_name ?? process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default";
+  const wm = orchestrator.getWorkflowManager();
+  const result = await wm.reviewReadinessCheck(args.task_id, devId);
+
+  const lines: string[] = [`**${result.summary}**`, ""];
+  if (result.data.blockers?.length) {
+    lines.push("**Blockers:**", ...result.data.blockers.map((b) => `- ${b.message ?? b.type}${b.task ? ` (${b.task})` : ""}`), "");
+  }
+  lines.push(
+    "**Checks:**",
+    `- Sub-tasks complete: ${result.data.readiness.all_subtasks_complete !== false ? "Yes" : "No"}`,
+    `- Session complete: ${result.data.readiness.session_complete !== false ? "Yes" : "No"}`,
+    `- No conflicts: ${result.data.readiness.no_conflicts !== false ? "Yes" : "No"}`,
+    `- Tests/pipeline: ${result.data.readiness.tests_passing === undefined ? "Unknown" : result.data.readiness.tests_passing ? "Passing" : "Failing"}`
+  );
+  if (result.data.mr_url) lines.push("", `MR: ${result.data.mr_url}`);
+  lines.push("", "**Next steps:**", ...result.next_steps.map((s) => `- ${s}`));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/coordination/blocker-resolver.ts
+++ b/packages/core/src/tools/coordination/blocker-resolver.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { blockersResolver } from "../../flows/orchestration-flows.js";
+
+export function blockersResolverTool(): Tool {
+  return {
+    name: "blockers_resolver",
+    description: "Resolve a blocker: analyze type, find who can unblock, and create an unblocking task in Jira.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key (blocked)" },
+        blocker_reason: { type: "string", description: "Description of blocker" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runBlockersResolver(orc: RelayOrchestrator, args: { task_id: string; blocker_reason?: string }): Promise<string> {
+  const r = await blockersResolver(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/coordination/conflict-predictor.ts
+++ b/packages/core/src/tools/coordination/conflict-predictor.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { mergeConflictPredictor } from "../../flows/orchestration-flows.js";
+
+export function mergeConflictPredictorTool(): Tool {
+  return {
+    name: "merge_conflict_predictor",
+    description: "Predict merge conflicts: check who else is working on same files and suggest coordination or alternative tasks.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key" },
+        dev_name: { type: "string", description: "Developer id" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runMergeConflictPredictor(orc: RelayOrchestrator, args: { task_id: string; dev_name?: string }): Promise<string> {
+  const r = await mergeConflictPredictor(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/coordination/pair-matcher.ts
+++ b/packages/core/src/tools/coordination/pair-matcher.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { pairProgrammingMatcher } from "../../flows/orchestration-flows.js";
+
+export function pairProgrammingMatcherTool(): Tool {
+  return {
+    name: "pair_programming_matcher",
+    description: "Find an expert in the code area who is available for pairing on the task.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runPairProgrammingMatcher(orc: RelayOrchestrator, args: { task_id: string }): Promise<string> {
+  const r = await pairProgrammingMatcher(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_pair) lines.push("", "Suggested pair: " + r.suggested_pair);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/create-subtask-from-mr-review.ts
+++ b/packages/core/src/tools/create-subtask-from-mr-review.ts
@@ -1,0 +1,69 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../orchestrator.js";
+
+export function createSubtaskFromMrReviewTool(): Tool {
+  return {
+    name: "create_subtask_from_mr_review",
+    description:
+      "Combined Jira + GitLab: if the MR has review comments that require changes, create a Jira sub-task under the parent issue so the assignee can address feedback. Use after MR review; Relay checks GitLab MR notes/discussions and creates a sub-task via Jira MCP.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        jira_issue_key: {
+          type: "string",
+          description: "Parent Jira issue key (e.g. PROJ-42)",
+        },
+        merge_request_url: {
+          type: "string",
+          description: "MR URL (for sub-task description)",
+        },
+        project_id: {
+          type: "string",
+          description: "GitLab project ID or project path/name for listing MR notes",
+        },
+        project_name: {
+          type: "string",
+          description: "GitLab project name (alternative to project_id)",
+        },
+        mr_iid: {
+          type: "number",
+          description: "Merge request IID (numeric id in project)",
+        },
+        merge_request_id: {
+          type: "string",
+          description: "Merge request ID (alternative to mr_iid)",
+        },
+      },
+      required: ["jira_issue_key"],
+    },
+  };
+}
+
+export async function runCreateSubtaskFromMrReview(
+  orchestrator: RelayOrchestrator,
+  args: {
+    jira_issue_key: string;
+    merge_request_url?: string;
+    project_id?: string;
+    project_name?: string;
+    mr_iid?: number;
+    merge_request_id?: string;
+  }
+): Promise<string> {
+  const result = await orchestrator.createSubtaskFromMrReview(args.jira_issue_key, {
+    mergeRequestUrl: args.merge_request_url,
+    projectId: args.project_id,
+    projectName: args.project_name,
+    mrIid: args.mr_iid,
+    mergeRequestId: args.merge_request_id,
+  });
+  if (result.error) {
+    return `Sub-task creation failed: ${result.error}`;
+  }
+  if (!result.created) {
+    return `Sub-task was not created.${result.noteCount != null ? ` (MR had ${result.noteCount} note(s).)` : ""}`;
+  }
+  const keyPart = result.subtaskKey ? ` **${result.subtaskKey}**` : "";
+  const notePart = result.noteCount != null ? ` (${result.noteCount} review note(s) on MR).` : "";
+  return `Jira sub-task created${keyPart} under ${args.jira_issue_key} to address MR review feedback.${notePart}`;
+}

--- a/packages/core/src/tools/deployment/deploy-impact.ts
+++ b/packages/core/src/tools/deployment/deploy-impact.ts
@@ -1,0 +1,25 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { deployImpactAnalyzer } from "../../flows/orchestration-flows.js";
+
+export function deployImpactAnalyzerTool(): Tool {
+  return {
+    name: "deploy_impact_analyzer",
+    description: "Analyze deploy impact: commits in release, affected stories, and generate release notes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        version: { type: "string", description: "Release version" },
+        project_key: { type: "string", description: "Jira project key" },
+      },
+    },
+  };
+}
+
+export async function runDeployImpactAnalyzer(orc: RelayOrchestrator, args: { version?: string; project_key?: string }): Promise<string> {
+  const r = await deployImpactAnalyzer(orc, args);
+  const lines = [r.summary];
+  if (r.issues_in_scope.length) lines.push("", "Issues: " + r.issues_in_scope.join(", "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/deployment/pre-deploy-check.ts
+++ b/packages/core/src/tools/deployment/pre-deploy-check.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { preDeployChecklist } from "../../flows/orchestration-flows.js";
+
+export function preDeployChecklistTool(): Tool {
+  return {
+    name: "pre_deploy_checklist",
+    description: "Pre-deploy check: all stories Done, MRs merged, tests passing. Returns blockers if not ready.",
+    inputSchema: {
+      type: "object",
+      properties: { project_key: { type: "string", description: "Jira project key" } },
+    },
+  };
+}
+
+export async function runPreDeployChecklist(orc: RelayOrchestrator, args: { project_key?: string }): Promise<string> {
+  const r = await preDeployChecklist(orc, args);
+  const lines = [r.summary];
+  if (r.blockers.length) lines.push("", "Blockers:", ...r.blockers.map((b) => "- " + b));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/deployment/rollback-recommender.ts
+++ b/packages/core/src/tools/deployment/rollback-recommender.ts
@@ -1,0 +1,16 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { rollbackRecommender } from "../../flows/orchestration-flows.js";
+
+export function rollbackRecommenderTool(): Tool {
+  return {
+    name: "rollback_recommender",
+    description: "Recommend rollback when errors spike post-deploy. Use with monitoring to find culprit and suggest revert.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runRollbackRecommender(orc: RelayOrchestrator): Promise<string> {
+  const r = await rollbackRecommender(orc);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/handoffs/cross-timezone-relay.ts
+++ b/packages/core/src/tools/handoffs/cross-timezone-relay.ts
@@ -1,0 +1,25 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { crossTimezoneRelay } from "../../flows/orchestration-flows.js";
+
+export function crossTimezoneRelayTool(): Tool {
+  return {
+    name: "cross_timezone_relay",
+    description: "End your session and relay to the next timezone. Suggests the best next developer (by recent handoffs) and prepares handoff.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dev_name: { type: "string", description: "Developer id" },
+        suggest_only: { type: "boolean", description: "Only suggest recipient, do not create handoff" },
+      },
+    },
+  };
+}
+
+export async function runCrossTimezoneRelay(orc: RelayOrchestrator, args: { dev_name?: string; suggest_only?: boolean }): Promise<string> {
+  const r = await crossTimezoneRelay(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_handoff_to) lines.push("", "Suggested: " + r.suggested_handoff_to);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/handoffs/knowledge-transfer.ts
+++ b/packages/core/src/tools/handoffs/knowledge-transfer.ts
@@ -1,0 +1,27 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { knowledgeTransfer } from "../../flows/orchestration-flows.js";
+
+export function knowledgeTransferTool(): Tool {
+  return {
+    name: "knowledge_transfer",
+    description: "Create a knowledge transfer package for a task: related past tasks, handoff history, and context for onboarding.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key (e.g. PROJ-42)" },
+        dev_name: { type: "string", description: "Developer id" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runKnowledgeTransfer(orc: RelayOrchestrator, args: { task_id: string; dev_name?: string }): Promise<string> {
+  const r = await knowledgeTransfer(orc, args);
+  const lines = [r.summary];
+  if (r.related_tasks.length) lines.push("", "Related tasks:", ...r.related_tasks.map((t) => "- " + t));
+  if (r.handoff_history.length) lines.push("", "Handoff history:", ...r.handoff_history.map((h) => "- " + h));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/handoffs/smart-handoff.ts
+++ b/packages/core/src/tools/handoffs/smart-handoff.ts
@@ -1,0 +1,116 @@
+/**
+ * Smart Handoff — Intelligent handoffs with MR analysis and Jira sub-tasks.
+ * Category: Handoffs. MCPs: Jira + GitLab + SQLite.
+ *
+ * Orchestrates: find MR for task, analyze review comments, create Jira sub-tasks,
+ * add handoff comment to Jira, create handoff record.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+
+export function smartHandoffTool(): Tool {
+  return {
+    name: "smart_handoff",
+    description: `Hand off your work to another developer with complete context.
+
+I'll automatically:
+- Find your GitLab MR and analyze review comments
+- Create Jira sub-tasks for any requested changes
+- Add a comprehensive handoff comment to Jira
+- Package everything for the next developer
+
+They'll get exactly what they need to continue your work.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: {
+          type: "string",
+          description: "Jira task ID (e.g. PROJ-42)",
+        },
+        from_dev: {
+          type: "string",
+          description: "Your developer id (creating the handoff)",
+        },
+        to_dev: {
+          type: "string",
+          description: "Developer id receiving the handoff",
+        },
+        auto_analyze: {
+          type: "boolean",
+          description: "Analyze MR and create sub-tasks from review comments (default: true)",
+          default: true,
+        },
+        custom_notes: {
+          type: "string",
+          description: "Additional context for the handoff",
+        },
+        project_id: {
+          type: "string",
+          description: "GitLab project ID or path (to find MR); optional if RELAY_GITLAB_PROJECT is set",
+        },
+        project_name: {
+          type: "string",
+          description: "GitLab project name (alternative to project_id)",
+        },
+        merge_request_url: {
+          type: "string",
+          description: "MR URL if you already have it (skips MR discovery)",
+        },
+        mr_iid: {
+          type: "number",
+          description: "Merge request IID when project_id is set",
+        },
+      },
+      required: ["task_id", "from_dev", "to_dev"],
+    },
+  };
+}
+
+export async function runSmartHandoff(
+  orchestrator: RelayOrchestrator,
+  args: {
+    task_id: string;
+    from_dev: string;
+    to_dev: string;
+    auto_analyze?: boolean;
+    custom_notes?: string;
+    project_id?: string;
+    project_name?: string;
+    merge_request_url?: string;
+    mr_iid?: number;
+  }
+): Promise<string> {
+  const wm = orchestrator.getWorkflowManager();
+  const result = await wm.smartHandoff({
+    task_id: args.task_id,
+    from_dev: args.from_dev,
+    to_dev: args.to_dev,
+    auto_analyze: args.auto_analyze,
+    custom_notes: args.custom_notes,
+    project_id: args.project_id,
+    project_name: args.project_name,
+    merge_request_url: args.merge_request_url,
+    mr_iid: args.mr_iid,
+  });
+
+  const lines: string[] = [
+    `**${result.summary}**`,
+    "",
+    "**Actions:**",
+    ...result.actions_taken.map((a) => `- ${a}`),
+    "",
+    "**Next steps:**",
+    ...result.next_steps.map((s) => `- ${s}`),
+  ];
+  if (result.warnings?.length) {
+    lines.push("", "**Warnings:**", ...result.warnings.map((w) => `- ${w}`));
+  }
+  if (result.data.sub_tasks_created?.length) {
+    lines.push("", "**Sub-tasks created:**", ...result.data.sub_tasks_created.map((s) => `- ${s.key}: ${s.summary}`));
+  }
+  if (result.estimated_effort_minutes) {
+    lines.push("", `Estimated effort: ${result.estimated_effort_minutes} minutes`);
+  }
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Tool registry for Relay intelligent orchestration tools (38 tools).
+ */
+
+export { smartHandoffTool, runSmartHandoff } from "./handoffs/smart-handoff.js";
+export { crossTimezoneRelayTool, runCrossTimezoneRelay } from "./handoffs/cross-timezone-relay.js";
+export { knowledgeTransferTool, runKnowledgeTransfer } from "./handoffs/knowledge-transfer.js";
+
+export { reviewReadinessTool, runReviewReadinessCheck } from "./code-review/review-readiness.js";
+export { autoReviewAssignmentTool, runAutoReviewAssignment } from "./code-review/auto-review-assignment.js";
+export { reviewBottleneckDetectorTool, runReviewBottleneckDetector } from "./code-review/review-bottleneck.js";
+export { reviewImpactAnalyzerTool, runReviewImpactAnalyzer } from "./code-review/review-impact.js";
+
+export { contextResurrectionTool, runContextResurrection } from "./work-sessions/context-resurrection.js";
+export { workSessionAnalyticsTool, runWorkSessionAnalytics } from "./work-sessions/session-analytics.js";
+export { focusTimeProtectorTool, runFocusTimeProtector } from "./work-sessions/focus-protector.js";
+
+export { sprintAutoPlanningTool, runSprintAutoPlanning } from "./sprint-planning/sprint-auto-plan.js";
+export { capacityForecastingTool, runCapacityForecasting } from "./sprint-planning/capacity-forecast.js";
+export { storyBreakdownAssistantTool, runStoryBreakdownAssistant } from "./sprint-planning/story-breakdown.js";
+
+export { technicalDebtTrackerTool, runTechnicalDebtTracker } from "./quality/tech-debt-tracker.js";
+export { codeQualityGateTool, runCodeQualityGate } from "./quality/quality-gate.js";
+export { flakyTestDetectorTool, runFlakyTestDetector } from "./quality/flaky-test-detective.js";
+
+export { mergeConflictPredictorTool, runMergeConflictPredictor } from "./coordination/conflict-predictor.js";
+export { pairProgrammingMatcherTool, runPairProgrammingMatcher } from "./coordination/pair-matcher.js";
+export { blockersResolverTool, runBlockersResolver } from "./coordination/blocker-resolver.js";
+
+export { preDeployChecklistTool, runPreDeployChecklist } from "./deployment/pre-deploy-check.js";
+export { deployImpactAnalyzerTool, runDeployImpactAnalyzer } from "./deployment/deploy-impact.js";
+export { rollbackRecommenderTool, runRollbackRecommender } from "./deployment/rollback-recommender.js";
+
+export { developerHappinessTrackerTool, runDeveloperHappinessTracker } from "./metrics/happiness-tracker.js";
+export { storyCycleTimeAnalyzerTool, runStoryCycleTimeAnalyzer } from "./metrics/cycle-time-analyzer.js";
+export { teamVelocityDashboardTool, runTeamVelocityDashboard } from "./metrics/velocity-dashboard.js";
+
+export { newDeveloperGuideTool, runNewDeveloperGuide } from "./onboarding/new-dev-guide.js";
+export { codeAreaMapperTool, runCodeAreaMapper } from "./onboarding/code-area-mapper.js";
+export { bestPracticesEnforcerTool, runBestPracticesEnforcer } from "./onboarding/best-practices.js";
+
+export { interruptionMinimizerTool, runInterruptionMinimizer } from "./optimization/interruption-minimizer.js";
+export { taskSwitcherTool, runTaskSwitcher } from "./optimization/task-switcher.js";
+export { workLifeBalanceMonitorTool, runWorkLifeBalanceMonitor } from "./optimization/work-life-balance.js";
+
+export { smartTaskRecommenderTool, runSmartTaskRecommender } from "./ai-driven/task-recommender.js";
+export { codePatternLearnerTool, runCodePatternLearner } from "./ai-driven/pattern-learner.js";
+export { sprintRiskPredictorTool, runSprintRiskPredictor } from "./ai-driven/risk-predictor.js";
+export { automatedRetrospectiveTool, runAutomatedRetrospective } from "./ai-driven/auto-retrospective.js";
+
+export { securityReviewTriggerTool, runSecurityReviewTrigger } from "./security/security-review-trigger.js";
+export { complianceCheckerTool, runComplianceChecker } from "./security/compliance-checker.js";
+export { dependencyVulnerabilityScannerTool, runDependencyVulnerabilityScanner } from "./security/dependency-scanner.js";

--- a/packages/core/src/tools/metrics/cycle-time-analyzer.ts
+++ b/packages/core/src/tools/metrics/cycle-time-analyzer.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { storyCycleTimeAnalyzer } from "../../flows/orchestration-flows.js";
+
+export function storyCycleTimeAnalyzerTool(): Tool {
+  return {
+    name: "story_cycle_time_analyzer",
+    description: "Analyze story cycle time: work time vs calendar time. Identify delays from handoffs or interruptions.",
+    inputSchema: {
+      type: "object",
+      properties: { project_key: { type: "string", description: "Jira project key" } },
+    },
+  };
+}
+
+export async function runStoryCycleTimeAnalyzer(orc: RelayOrchestrator, args: { project_key?: string }): Promise<string> {
+  const r = await storyCycleTimeAnalyzer(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/metrics/happiness-tracker.ts
+++ b/packages/core/src/tools/metrics/happiness-tracker.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { developerHappinessTracker } from "../../flows/orchestration-flows.js";
+
+export function developerHappinessTrackerTool(): Tool {
+  return {
+    name: "developer_happiness_tracker",
+    description: "Detect burnout signals: long sessions, interruptions, rework. Alert lead for check-in.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runDeveloperHappinessTracker(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await developerHappinessTracker(orc, args);
+  const lines = [r.summary];
+  if (r.signals.length) lines.push("", "Signals: " + r.signals.join("; "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/metrics/velocity-dashboard.ts
+++ b/packages/core/src/tools/metrics/velocity-dashboard.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { teamVelocityDashboard } from "../../flows/orchestration-flows.js";
+
+export function teamVelocityDashboardTool(): Tool {
+  return {
+    name: "team_velocity_dashboard",
+    description: "Show team velocity: completed stories, commits, code churn, and trend analysis.",
+    inputSchema: {
+      type: "object",
+      properties: { project_key: { type: "string", description: "Jira project key" } },
+    },
+  };
+}
+
+export async function runTeamVelocityDashboard(orc: RelayOrchestrator, args: { project_key?: string }): Promise<string> {
+  const r = await teamVelocityDashboard(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/onboarding/best-practices.ts
+++ b/packages/core/src/tools/onboarding/best-practices.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { bestPracticesEnforcer } from "../../flows/orchestration-flows.js";
+
+export function bestPracticesEnforcerTool(): Tool {
+  return {
+    name: "best_practices_enforcer",
+    description: "Check MR for missing tests or docs. Create sub-tasks if standards not met. Use before or on MR.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runBestPracticesEnforcer(orc: RelayOrchestrator, args: { task_id: string }): Promise<string> {
+  const r = await bestPracticesEnforcer(orc, args);
+  const lines = [r.summary];
+  if (r.gaps?.length) lines.push("", "Gaps: " + r.gaps.join("; "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/onboarding/code-area-mapper.ts
+++ b/packages/core/src/tools/onboarding/code-area-mapper.ts
@@ -1,0 +1,26 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { codeAreaMapper } from "../../flows/orchestration-flows.js";
+
+export function codeAreaMapperTool(): Tool {
+  return {
+    name: "code_area_mapper",
+    description: "For unfamiliar code: who wrote it, related past stories, and suggest pairing with owner.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key" },
+        area: { type: "string", description: "Code area or module name" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runCodeAreaMapper(orc: RelayOrchestrator, args: { task_id: string; area?: string }): Promise<string> {
+  const r = await codeAreaMapper(orc, args);
+  const lines = [r.summary];
+  if (r.related_stories?.length) lines.push("", "Related: " + r.related_stories.join(", "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/onboarding/new-dev-guide.ts
+++ b/packages/core/src/tools/onboarding/new-dev-guide.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { newDeveloperGuide } from "../../flows/orchestration-flows.js";
+
+export function newDeveloperGuideTool(): Tool {
+  return {
+    name: "new_developer_guide",
+    description: "Create onboarding plan: find good-first issues and well-documented areas for new devs.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runNewDeveloperGuide(orc: RelayOrchestrator): Promise<string> {
+  const r = await newDeveloperGuide(orc);
+  const lines = [r.summary];
+  if (r.good_first_issues.length) lines.push("", "Good first issues:", ...r.good_first_issues.map((i) => "- " + i));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/optimization/interruption-minimizer.ts
+++ b/packages/core/src/tools/optimization/interruption-minimizer.ts
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { interruptionMinimizer } from "../../flows/orchestration-flows.js";
+
+export function interruptionMinimizerTool(): Tool {
+  return {
+    name: "interruption_minimizer",
+    description: "Minimize interruptions: suggest focus time blocks and batch notifications outside focus.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runInterruptionMinimizer(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await interruptionMinimizer(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/optimization/task-switcher.ts
+++ b/packages/core/src/tools/optimization/task-switcher.ts
@@ -1,0 +1,26 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { taskSwitcher } from "../../flows/orchestration-flows.js";
+
+export function taskSwitcherTool(): Tool {
+  return {
+    name: "task_switcher",
+    description: "Switch to another task: save current context, load new task context, track switch cost.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        new_task_id: { type: "string", description: "Jira issue key to switch to" },
+        dev_name: { type: "string", description: "Developer id" },
+      },
+      required: ["new_task_id"],
+    },
+  };
+}
+
+export async function runTaskSwitcher(orc: RelayOrchestrator, args: { new_task_id: string; dev_name?: string }): Promise<string> {
+  const r = await taskSwitcher(orc, args);
+  const lines = [r.summary];
+  if (r.previous_task) lines.push("", "Previous: " + r.previous_task);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/optimization/work-life-balance.ts
+++ b/packages/core/src/tools/optimization/work-life-balance.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { workLifeBalanceMonitor } from "../../flows/orchestration-flows.js";
+
+export function workLifeBalanceMonitorTool(): Tool {
+  return {
+    name: "work_life_balance_monitor",
+    description: "Track work hours; detect >50hr weeks or weekend work and alert.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runWorkLifeBalanceMonitor(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await workLifeBalanceMonitor(orc, args);
+  const lines = [r.summary];
+  if (r.alert) lines.push("", "Alert: " + r.alert);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/quality/flaky-test-detective.ts
+++ b/packages/core/src/tools/quality/flaky-test-detective.ts
@@ -1,0 +1,16 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { flakyTestDetector } from "../../flows/orchestration-flows.js";
+
+export function flakyTestDetectorTool(): Tool {
+  return {
+    name: "flaky_test_detective",
+    description: "Find flaky tests from CI failure history. Create Jira issues for intermittent failures.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runFlakyTestDetector(orc: RelayOrchestrator): Promise<string> {
+  const r = await flakyTestDetector(orc);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/quality/quality-gate.ts
+++ b/packages/core/src/tools/quality/quality-gate.ts
@@ -1,0 +1,26 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { codeQualityGate } from "../../flows/orchestration-flows.js";
+
+export function codeQualityGateTool(): Tool {
+  return {
+    name: "code_quality_gate",
+    description: "Run quality gate for a task: sub-tasks done, tests passing, no conflicts. Blocks merge if not passed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "Jira issue key" },
+        dev_name: { type: "string", description: "Developer id" },
+      },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runCodeQualityGate(orc: RelayOrchestrator, args: { task_id: string; dev_name?: string }): Promise<string> {
+  const r = await codeQualityGate(orc, args);
+  const lines = [r.summary];
+  if (r.blockers.length) lines.push("", "Blockers:", ...r.blockers.map((b) => "- " + b));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/quality/tech-debt-tracker.ts
+++ b/packages/core/src/tools/quality/tech-debt-tracker.ts
@@ -1,0 +1,16 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { technicalDebtTracker } from "../../flows/orchestration-flows.js";
+
+export function technicalDebtTrackerTool(): Tool {
+  return {
+    name: "technical_debt_tracker",
+    description: "Scan codebase for TODO/FIXME/HACK and create Jira tech-debt issues. Use grep or GitLab file search.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runTechnicalDebtTracker(orc: RelayOrchestrator): Promise<string> {
+  const r = await technicalDebtTracker(orc);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/security/compliance-checker.ts
+++ b/packages/core/src/tools/security/compliance-checker.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { complianceChecker } from "../../flows/orchestration-flows.js";
+
+export function complianceCheckerTool(): Tool {
+  return {
+    name: "compliance_checker",
+    description: "Detect PII handling changes and ensure docs updated. Create compliance tasks and block deploy if needed.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runComplianceChecker(orc: RelayOrchestrator, args: { task_id: string }): Promise<string> {
+  const r = await complianceChecker(orc, args);
+  const lines = [r.summary];
+  if (r.compliance_tasks?.length) lines.push("", "Tasks: " + r.compliance_tasks.join("; "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/security/dependency-scanner.ts
+++ b/packages/core/src/tools/security/dependency-scanner.ts
@@ -1,0 +1,16 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { dependencyVulnerabilityScanner } from "../../flows/orchestration-flows.js";
+
+export function dependencyVulnerabilityScannerTool(): Tool {
+  return {
+    name: "dependency_vulnerability_scanner",
+    description: "Scan package.json/requirements.txt for vulnerabilities. Create Jira security issues for findings.",
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+export async function runDependencyVulnerabilityScanner(orc: RelayOrchestrator): Promise<string> {
+  const r = await dependencyVulnerabilityScanner(orc);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/security/security-review-trigger.ts
+++ b/packages/core/src/tools/security/security-review-trigger.ts
@@ -1,0 +1,20 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { securityReviewTrigger } from "../../flows/orchestration-flows.js";
+
+export function securityReviewTriggerTool(): Tool {
+  return {
+    name: "security_review_trigger",
+    description: "If MR touches sensitive files (auth, payments), request security review and block merge until approved.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runSecurityReviewTrigger(orc: RelayOrchestrator, args: { task_id: string }): Promise<string> {
+  const r = await securityReviewTrigger(orc, args);
+  return r.summary + "\n\nNext: " + r.next_steps.join("; ");
+}

--- a/packages/core/src/tools/sprint-planning/capacity-forecast.ts
+++ b/packages/core/src/tools/sprint-planning/capacity-forecast.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { capacityForecasting } from "../../flows/orchestration-flows.js";
+
+export function capacityForecastingTool(): Tool {
+  return {
+    name: "capacity_forecasting",
+    description: "Check sprint capacity: assigned work vs available hours. Alerts if overcommitted.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runCapacityForecasting(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await capacityForecasting(orc, args);
+  const lines = [r.summary];
+  if (r.alert) lines.push("", "Alert: " + r.alert);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/sprint-planning/sprint-auto-plan.ts
+++ b/packages/core/src/tools/sprint-planning/sprint-auto-plan.ts
@@ -1,0 +1,25 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { sprintAutoPlanning } from "../../flows/orchestration-flows.js";
+
+export function sprintAutoPlanningTool(): Tool {
+  return {
+    name: "sprint_auto_planning",
+    description: "Plan a sprint: analyze backlog and suggest assignments by capacity and expertise.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sprint_id: { type: "string", description: "Sprint identifier" },
+        project_key: { type: "string", description: "Jira project key" },
+      },
+    },
+  };
+}
+
+export async function runSprintAutoPlanning(orc: RelayOrchestrator, args: { sprint_id?: string; project_key?: string }): Promise<string> {
+  const r = await sprintAutoPlanning(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_assignments.length) lines.push("", "Suggested: " + r.suggested_assignments.join(", "));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/sprint-planning/story-breakdown.ts
+++ b/packages/core/src/tools/sprint-planning/story-breakdown.ts
@@ -1,0 +1,23 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { storyBreakdownAssistant } from "../../flows/orchestration-flows.js";
+
+export function storyBreakdownAssistantTool(): Tool {
+  return {
+    name: "story_breakdown_assistant",
+    description: "For large stories (13+ pts), suggest a breakdown into sub-tasks based on similar past work.",
+    inputSchema: {
+      type: "object",
+      properties: { task_id: { type: "string", description: "Jira issue key" } },
+      required: ["task_id"],
+    },
+  };
+}
+
+export async function runStoryBreakdownAssistant(orc: RelayOrchestrator, args: { task_id: string }): Promise<string> {
+  const r = await storyBreakdownAssistant(orc, args);
+  const lines = [r.summary];
+  if (r.suggested_subtasks.length) lines.push("", "Suggested sub-tasks:", ...r.suggested_subtasks.map((s) => "- " + s));
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/work-sessions/context-resurrection.ts
+++ b/packages/core/src/tools/work-sessions/context-resurrection.ts
@@ -1,0 +1,78 @@
+/**
+ * Context Resurrection — Recover context after time away.
+ * Category: Work Sessions. MCPs: Jira + GitLab + SQLite.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+
+export function contextResurrectionTool(): Tool {
+  return {
+    name: "context_resurrection",
+    description: `Get your context back after time away.
+
+I'll look at:
+- Your last work session (what you were doing)
+- Jira: Any updates on your task since then
+- GitLab: Branch status and any conflicts
+
+You'll get a short summary of where you left off and what changed while you were away.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        dev_name: {
+          type: "string",
+          description: "Developer id (defaults to RELAY_DEVELOPER_ID or current user)",
+        },
+        days_away: {
+          type: "number",
+          description: "Optional: number of days away (used for messaging)",
+        },
+      },
+    },
+  };
+}
+
+export async function runContextResurrection(
+  orchestrator: RelayOrchestrator,
+  args: { dev_name?: string; days_away?: number }
+): Promise<string> {
+  const devId = args.dev_name ?? process.env["RELAY_DEVELOPER_ID"] ?? process.env["USER"] ?? "default";
+  const wm = orchestrator.getWorkflowManager();
+  const result = await wm.contextResurrection(devId);
+
+  if (!result.lastSession) {
+    return "No previous work sessions found. Start with **start_task** or **whats_up** to see your current context.";
+  }
+
+  const last = result.lastSession;
+  const microTasks = await wm.getMicroTasks(last.id);
+  const doneCount = microTasks.filter((t) => t.status === "done").length;
+  const totalCount = microTasks.length;
+  const progress = totalCount ? `${doneCount}/${totalCount} micro-tasks complete` : "No micro-tasks";
+
+  const lines: string[] = [
+    "**Welcome back.** Here's what happened while you were away.",
+    "",
+    "**Last session**",
+    `- Task: ${last.jira_issue_key ?? "—"} ${last.jira_issue_summary ? `— ${last.jira_issue_summary}` : ""}`,
+    `- Ended: ${last.ended_at ?? "—"}`,
+    `- Progress: ${progress}`,
+    `- Branch: ${last.branch_name ?? "—"}`,
+    "",
+    "**Where you left off**",
+    `- ${last.jira_issue_summary ?? last.jira_issue_key ?? "Previous task"}`,
+  ];
+  if (result.nextMicroTask) lines.push(`- Next micro-task: ${result.nextMicroTask}`);
+  if (result.jiraUpdates.length) {
+    lines.push("", "**Jira updates**", ...result.jiraUpdates.map((u) => `- ${u.task}: ${u.change}`));
+  }
+  if (result.conflicts.length) {
+    lines.push("", "**Conflicts**", ...result.conflicts.map((c) => `- ${c.reason}`));
+  }
+  if (result.activeSession) {
+    lines.push("", "You have an active session; consider **handoff_task** or **complete_task** if switching context.");
+  }
+  lines.push("", "**Next steps**", "- Run **whats_up** for full status", "- Run **start_task** to continue with the same or a new task");
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/work-sessions/focus-protector.ts
+++ b/packages/core/src/tools/work-sessions/focus-protector.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { focusTimeProtector } from "../../flows/orchestration-flows.js";
+
+export function focusTimeProtectorTool(): Tool {
+  return {
+    name: "focus_time_protector",
+    description: "Enable focus mode: detect active session and suggest batching notifications until you complete or hand off.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runFocusTimeProtector(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await focusTimeProtector(orc, args);
+  const lines = [r.summary];
+  if (r.session_id) lines.push("Session: " + r.session_id);
+  lines.push("", "Next: " + r.next_steps.join("; "));
+  return lines.join("\n");
+}

--- a/packages/core/src/tools/work-sessions/session-analytics.ts
+++ b/packages/core/src/tools/work-sessions/session-analytics.ts
@@ -1,0 +1,20 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { RelayOrchestrator } from "../../orchestrator.js";
+import { workSessionAnalytics } from "../../flows/orchestration-flows.js";
+
+export function workSessionAnalyticsTool(): Tool {
+  return {
+    name: "work_session_analytics",
+    description: "Show your work patterns: session count, total minutes, and status breakdown. Suggests productive schedule.",
+    inputSchema: {
+      type: "object",
+      properties: { dev_name: { type: "string", description: "Developer id" } },
+    },
+  };
+}
+
+export async function runWorkSessionAnalytics(orc: RelayOrchestrator, args: { dev_name?: string }): Promise<string> {
+  const r = await workSessionAnalytics(orc, args);
+  const lines = [r.summary, "", "By status: " + JSON.stringify(r.by_status), "", "Next: " + r.next_steps.join("; ")];
+  return lines.join("\n");
+}

--- a/packages/core/src/types/orchestration-tools.ts
+++ b/packages/core/src/types/orchestration-tools.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared types for Relay intelligent orchestration tools.
+ * Used across handoffs, code-review, work-sessions, and other categories.
+ */
+
+// --- Jira state awareness (used by BaseOrchestrationTool and all 38 tools) ---
+
+/** Current state of a Jira issue from Jira MCP get_issue. */
+export interface JiraIssueState {
+  key: string;
+  summary: string | null;
+  statusName: string;
+  /** e.g. "To Do", "In Progress", "Done" — from statusCategory.key or name */
+  statusCategory: string;
+  assigneeId: string | null;
+  assigneeName: string | null;
+  /** Sub-task keys with their status for validation */
+  subtasks: Array<{ key: string; statusName: string; statusCategory: string }>;
+  /** Raw updated date if needed */
+  updated?: string;
+}
+
+/** Result of resolving task context (auto-detect from session or use provided task_id). */
+export interface ResolvedTaskContext {
+  issueKey: string;
+  state: JiraIssueState;
+  /** Whether issueKey came from active session (auto-detected) */
+  fromSession: boolean;
+  /** Active session id if any for this issue */
+  sessionId: string | null;
+}
+
+/** Result of validating a state transition before performing it. */
+export interface StateValidationResult {
+  valid: boolean;
+  error?: string;
+  /** Suggested action when invalid (e.g. "Transition to In Progress first") */
+  suggestion?: string;
+}
+
+/** Common transitions we care about; workflow may vary by project. */
+export type JiraTransitionIntent = "start" | "complete" | "block" | "unblock" | "code_review";
+
+export interface OrchestrationResultBase {
+  summary: string;
+  actions_taken: string[];
+  next_steps: string[];
+  warnings?: string[];
+}
+
+export interface ReadinessData {
+  all_subtasks_complete?: boolean;
+  tests_passing?: boolean;
+  no_conflicts?: boolean;
+  session_complete?: boolean;
+}
+
+export interface BlockerItem {
+  type: string;
+  task?: string;
+  test?: string;
+  file?: string;
+  message?: string;
+}
+
+export interface ReviewReadinessResult extends OrchestrationResultBase {
+  data: {
+    readiness: ReadinessData;
+    blockers?: BlockerItem[];
+    reviewers_assigned?: string[];
+    mr_url?: string;
+  };
+}
+
+export interface ContextResurrectionResult extends OrchestrationResultBase {
+  data: {
+    last_session?: {
+      task: string | null;
+      ended_at: string;
+      progress: string;
+      branch_name: string | null;
+    };
+    changes_while_away?: {
+      jira_updates: Array<{ task: string; change: string }>;
+      gitlab_updates: Array<{ mr?: number; change: string }>;
+      conflicts: Array<{ file?: string; reason: string }>;
+    };
+    resume_context?: {
+      where_you_left_off: string;
+      next_micro_task?: string;
+      estimated_time_remaining?: string;
+    };
+  };
+  estimated_effort_minutes?: number;
+}
+
+export interface SmartHandoffResult extends OrchestrationResultBase {
+  data: {
+    handoff_id: string;
+    task_id: string;
+    merge_request?: {
+      iid: number;
+      url: string;
+      state: string;
+      has_conflicts?: boolean;
+      source_branch?: string;
+      target_branch?: string;
+    };
+    review_status?: {
+      changes_requested: boolean;
+      unresolved_threads: number;
+      total_comments: number;
+    };
+    sub_tasks_created: Array<{ key: string; summary: string; priority?: string }>;
+  };
+  estimated_effort_minutes?: number;
+}
+
+/** Parsed review change from MR notes (rule-based extraction). */
+export interface RequiredChange {
+  summary: string;
+  description: string;
+  priority: "high" | "medium" | "low";
+  estimatedMinutes: number;
+  reviewerUsername?: string;
+}
+
+export interface ReviewCommentsAnalysis {
+  changesRequested: boolean;
+  requiredChanges: RequiredChange[];
+  unresolvedThreads: number;
+  totalComments: number;
+}

--- a/packages/core/src/workflow-manager.ts
+++ b/packages/core/src/workflow-manager.ts
@@ -6,6 +6,11 @@
 import { nanoid } from "nanoid";
 import type { IRelayDb } from "./db-adapter.js";
 import type { McpClientsManager } from "./mcp-clients.js";
+import { analyzeReviewComments } from "./lib/ai-analyzer.js";
+import * as JiraState from "./lib/jira-state.js";
+import type { SmartHandoffResult } from "./types/orchestration-tools.js";
+import type { ReviewReadinessResult, BlockerItem } from "./types/orchestration-tools.js";
+import type { JiraIssueState, ResolvedTaskContext, StateValidationResult, JiraTransitionIntent } from "./types/orchestration-tools.js";
 
 export interface MorningCheckinResult {
   pendingHandoffs: Array<{ id: string; title: string; from: string; summary: string | null }>;
@@ -38,6 +43,10 @@ export interface CreateHandoffInput {
   fileList?: string;
   blockersNotes?: string;
   workSessionId?: string;
+  /** If set with jiraIssueKey, add a Jira comment with the MR link before creating the handoff. */
+  mergeRequestUrl?: string;
+  /** Jira issue key to add MR comment to (e.g. from active session). Used with mergeRequestUrl. */
+  jiraIssueKey?: string;
 }
 
 function defaultDeveloperId(): string {
@@ -94,6 +103,84 @@ export class WorkflowManager {
     private db: IRelayDb,
     private mcp: McpClientsManager
   ) {}
+
+  // --- Jira state awareness (used by BaseOrchestrationTool and all orchestration tools) ---
+
+  /** Query Jira for current issue state. Use before any action. */
+  async getJiraState(issueKey: string): Promise<JiraIssueState | null> {
+    return JiraState.getJiraState(this.mcp, issueKey);
+  }
+
+  /** Resolve task context: auto-detect from active session if task_id not provided. */
+  async resolveTaskContext(developerId: string, taskId?: string): Promise<ResolvedTaskContext | null> {
+    return JiraState.resolveTaskContext(this.mcp, this.db, developerId ?? defaultDeveloperId(), taskId);
+  }
+
+  /** Validate a state transition is legal before performing it. */
+  validateTransition(currentState: JiraIssueState, intent: JiraTransitionIntent, targetStatus?: string): StateValidationResult {
+    return JiraState.validateTransition(currentState, intent, targetStatus);
+  }
+
+  /** Sync local state with Jira after actions (e.g. warn if Jira is Done but session still active). */
+  async syncLocalStateWithJira(issueKey: string, jiraState: JiraIssueState, developerId: string): Promise<{ synced: boolean; message?: string }> {
+    return JiraState.syncLocalStateWithJira(this.db, issueKey, jiraState, developerId ?? defaultDeveloperId());
+  }
+
+  /** Search Jira with JQL; returns issue keys and summaries. */
+  async searchJira(jql: string, maxResults = 20): Promise<Array<{ key: string; summary: string }>> {
+    const searchTool = await this.mcp.getJiraSearchTool();
+    const res = await this.mcp.callJiraTool(searchTool, { jql, query: jql, max_results: maxResults, maxResults, limit: maxResults });
+    if (res.isError || !res.content) return [];
+    return parseJiraIssues(res.content);
+  }
+
+  /** List GitLab merge requests for a project. */
+  async listMergeRequests(projectId: string, state: "opened" | "closed" | "merged" = "opened", limit = 20): Promise<Array<{ iid: number; title: string; web_url: string; state: string; source_branch: string; target_branch: string; created_at: string; updated_at: string }>> {
+    const listMrTool = await this.mcp.getGitLabMergeRequestsTool();
+    const res = await this.mcp.callGitTool(listMrTool, { project_id: projectId, project_name: projectId, state, limit });
+    if (res.isError || !res.content) return [];
+    try {
+      const data = JSON.parse(res.content);
+      const list = Array.isArray(data) ? data : data?.merge_requests ?? data?.results ?? [];
+      return list.map((m: any) => ({
+        iid: m.iid ?? m.iid,
+        title: m.title ?? "",
+        web_url: m.web_url ?? m.url ?? "",
+        state: m.state ?? "opened",
+        source_branch: m.source_branch ?? "",
+        target_branch: m.target_branch ?? "",
+        created_at: m.created_at ?? "",
+        updated_at: m.updated_at ?? "",
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Get MR notes/discussions for review comments. */
+  async getMergeRequestNotes(projectId: string, mrIid: number): Promise<Array<{ body: string; author?: string; resolved?: boolean }>> {
+    const notesTool = await this.mcp.getGitLabMrNotesTool();
+    const res = await this.mcp.callGitTool(notesTool, { project_id: projectId, project_name: projectId, merge_request_iid: mrIid, iid: mrIid });
+    if (res.isError || !res.content) return [];
+    try {
+      const data = JSON.parse(res.content);
+      const notes = data?.notes ?? (Array.isArray(data) ? data : []);
+      const discussions = data?.discussions ?? [];
+      const out: Array<{ body: string; author?: string; resolved?: boolean }> = [];
+      for (const n of notes) {
+        if (n.system) continue;
+        out.push({ body: n.body ?? "", author: n.author?.username, resolved: n.resolved });
+      }
+      for (const d of discussions) {
+        for (const n of d.notes ?? []) {
+          out.push({ body: n.body ?? "", author: n.author?.username, resolved: n.resolved });
+        }
+      }
+      return out;
+    } catch {
+      return [];
+    }
+  }
 
   async morningCheckin(developerId?: string): Promise<MorningCheckinResult> {
     const devId = developerId ?? defaultDeveloperId();
@@ -208,7 +295,39 @@ export class WorkflowManager {
     }
   }
 
+  /**
+   * Add a comment to a Jira issue with the MR link. Uses Jira MCP (add_comment / create_comment).
+   * Combined with GitLab: before handoff, add MR link into Jira so reviewers see it.
+   */
+  async addMrCommentToJira(
+    issueKey: string,
+    mergeRequestUrl: string,
+    extraText?: string
+  ): Promise<{ success: boolean; error?: string }> {
+    const commentTool = await this.mcp.getJiraAddCommentTool();
+    const body = extraText
+      ? `${extraText}\n\nMR: ${mergeRequestUrl}`
+      : `Merge request raised: ${mergeRequestUrl}`;
+    const args = {
+      issue_key: issueKey,
+      issueKey,
+      key: issueKey,
+      comment: body,
+      body,
+      text: body,
+    };
+    const res = await this.mcp.callJiraTool(commentTool, args);
+    return res.isError ? { success: false, error: res.content } : { success: true };
+  }
+
   async createHandoff(input: CreateHandoffInput): Promise<string> {
+    if (input.mergeRequestUrl && input.jiraIssueKey) {
+      await this.addMrCommentToJira(
+        input.jiraIssueKey,
+        input.mergeRequestUrl,
+        input.whatDone ? `Handoff: ${input.whatDone}` : undefined
+      ).catch(() => {});
+    }
     await this.db.ensureDeveloper(input.fromDeveloperId, input.fromDeveloperId);
     await this.db.ensureDeveloper(input.toDeveloperId, input.toDeveloperId);
     const id = nanoid();
@@ -227,6 +346,252 @@ export class WorkflowManager {
     });
     if (input.workSessionId) await this.db.endWorkSession(input.workSessionId, "handed_off");
     return id;
+  }
+
+  /**
+   * Combined Jira + GitLab: check MR review comments; if any exist, create a Jira sub-task to address them.
+   * Uses GitLab MCP for MR notes/discussions and Jira MCP for create issue/subtask.
+   */
+  async createSubtaskFromMrReview(
+    parentIssueKey: string,
+    options: {
+      mergeRequestUrl?: string;
+      projectId?: string;
+      projectName?: string;
+      mrIid?: number;
+      mergeRequestId?: string;
+    }
+  ): Promise<{ subtaskKey?: string; created: boolean; noteCount?: number; error?: string }> {
+    const notesTool = await this.mcp.getGitLabMrNotesTool();
+    const projectId = options.projectId ?? options.projectName;
+    const mrId = options.mrIid ?? options.mergeRequestId;
+    let noteCount = 0;
+    if (projectId != null && mrId != null) {
+      const notesRes = await this.mcp.callGitTool(notesTool, {
+        project_id: projectId,
+        project_name: projectId,
+        projectId,
+        merge_request_iid: options.mrIid ?? mrId,
+        merge_request_id: options.mergeRequestId ?? mrId,
+        iid: options.mrIid ?? mrId,
+      });
+      if (!notesRes.isError && notesRes.content) {
+        try {
+          const data = JSON.parse(notesRes.content);
+          const notes = Array.isArray(data) ? data : data?.notes ?? data?.discussions ?? [];
+          noteCount = notes.length;
+        } catch {
+          if (notesRes.content.trim().length > 0) noteCount = 1;
+        }
+      }
+    }
+    const hadNotes = projectId != null && mrId != null;
+    if (hadNotes && noteCount === 0) {
+      return { created: false, noteCount: 0, error: "No review comments on MR; no sub-task created." };
+    }
+    const createTool = await this.mcp.getJiraCreateIssueTool();
+    const summary =
+      noteCount > 0 ? "Address MR review feedback" : "Address MR review feedback (create sub-task from review)";
+    const description = options.mergeRequestUrl
+      ? `MR: ${options.mergeRequestUrl}${noteCount > 0 ? `\n\nReview comments require changes.` : ""}`
+      : noteCount > 0 ? "Review comments require changes." : "Sub-task created from MR review workflow.";
+    const createArgs: Record<string, unknown> = {
+      project: parentIssueKey.split("-")[0],
+      parent: parentIssueKey,
+      parentKey: parentIssueKey,
+      summary,
+      description,
+      issueType: "Sub-task",
+      issuetype: "Sub-task",
+      type: "Sub-task",
+    };
+    const createRes = await this.mcp.callJiraTool(createTool, createArgs);
+    if (createRes.isError) {
+      return { created: false, noteCount: noteCount || undefined, error: createRes.content };
+    }
+    const keyMatch = createRes.content.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
+    return {
+      subtaskKey: keyMatch ? keyMatch[1] : undefined,
+      created: true,
+      noteCount: noteCount || undefined,
+    };
+  }
+
+  /** Smart Handoff: find MR, analyze review comments, create sub-tasks, add Jira comment, create handoff record. */
+  async smartHandoff(params: {
+    task_id: string;
+    from_dev: string;
+    to_dev: string;
+    auto_analyze?: boolean;
+    custom_notes?: string;
+    project_id?: string;
+    project_name?: string;
+    merge_request_url?: string;
+    mr_iid?: number;
+  }): Promise<SmartHandoffResult> {
+    const actions: string[] = [];
+    const warnings: string[] = [];
+    const nextSteps: string[] = [];
+
+    // 1. Query Jira for current state before any action (CRITICAL: Jira state awareness)
+    const jiraState = await this.getJiraState(params.task_id);
+    if (!jiraState) {
+      throw new Error(`Jira issue ${params.task_id} not found or Jira unavailable. Check the issue key and Jira MCP connection.`);
+    }
+    actions.push(`Jira state: ${jiraState.statusName} (${jiraState.statusCategory})`);
+
+    // 2. Validate state transition: handoff from Done is unusual
+    const validation = this.validateTransition(jiraState, "complete");
+    if (!validation.valid && (jiraState.statusCategory?.toLowerCase() === "done" || jiraState.statusName?.toLowerCase() === "done")) {
+      warnings.push("Issue is already Done; handoff may still be created for context transfer.");
+    }
+
+    const subTasksCreated: Array<{ key: string; summary: string; priority?: string }> = [];
+
+    let mr: { iid: number; web_url: string; state: string; has_conflicts?: boolean; source_branch?: string; target_branch?: string; project_id?: number } | null = null;
+    const projectId = params.project_id ?? params.project_name ?? process.env["RELAY_GITLAB_PROJECT"];
+    if (projectId) {
+      const listMrTool = await this.mcp.getGitLabMergeRequestsTool();
+      const mrRes = await this.mcp.callGitTool(listMrTool, {
+        project_id: projectId,
+        project_name: projectId,
+        state: "opened",
+        limit: 20,
+      });
+      if (!mrRes.isError && mrRes.content) {
+        let list: any[] = [];
+        try {
+          const data = JSON.parse(mrRes.content);
+          list = Array.isArray(data) ? data : data?.merge_requests ?? data?.results ?? [];
+        } catch {
+          if (mrRes.content.trim()) list = [];
+        }
+        const taskId = params.task_id.toUpperCase();
+        const match = list.find(
+          (m: any) =>
+            (m.title && String(m.title).toUpperCase().includes(taskId)) ||
+            (m.source_branch && String(m.source_branch).toUpperCase().includes(taskId))
+        ) ?? list[0];
+        if (match) {
+          mr = {
+            iid: match.iid ?? match.iid,
+            web_url: match.web_url ?? match.url ?? "",
+            state: match.state ?? "opened",
+            has_conflicts: match.has_conflicts,
+            source_branch: match.source_branch,
+            target_branch: match.target_branch,
+            project_id: match.project_id,
+          };
+          actions.push(`Found GitLab MR !${mr.iid}`);
+        }
+      }
+    }
+    if (!mr && params.merge_request_url) {
+      const iidMatch = params.merge_request_url.match(/merge_requests\/(\d+)/);
+      mr = {
+        iid: iidMatch ? parseInt(iidMatch[1], 10) : 0,
+        web_url: params.merge_request_url,
+        state: "opened",
+      };
+      actions.push("Using provided MR URL");
+    }
+    if (!mr) warnings.push("No GitLab MR found for this task");
+
+    let reviewAnalysis: { changesRequested: boolean; requiredChanges: Array<{ summary: string; description: string; priority: string; estimatedMinutes: number; reviewerUsername?: string }>; unresolvedThreads: number; totalComments: number } | null = null;
+    if (mr && params.auto_analyze !== false && (params.mr_iid ?? mr.iid) && (mr.project_id ?? projectId)) {
+      const notesTool = await this.mcp.getGitLabMrNotesTool();
+      const notesRes = await this.mcp.callGitTool(notesTool, {
+        project_id: mr.project_id ?? projectId,
+        project_name: projectId,
+        merge_request_iid: params.mr_iid ?? mr.iid,
+        iid: params.mr_iid ?? mr.iid,
+      });
+      if (!notesRes.isError && notesRes.content) {
+        let notes: any[] = [];
+        let discussions: any[] = [];
+        try {
+          const data = JSON.parse(notesRes.content);
+          notes = data?.notes ?? (Array.isArray(data) ? data : []);
+          discussions = data?.discussions ?? [];
+        } catch {
+          if (notesRes.content.trim().length > 0) notes = [{}];
+        }
+        reviewAnalysis = analyzeReviewComments({ notes, discussions });
+        actions.push(`Analyzed ${reviewAnalysis.totalComments} review comment(s)`);
+        const createTool = await this.mcp.getJiraCreateIssueTool();
+        const projectKey = params.task_id.split("-")[0];
+        for (const ch of reviewAnalysis.requiredChanges) {
+          const summary = `[Review] ${ch.summary}`;
+          const description = `${ch.description}\n\nMR: ${mr.web_url}`;
+          const createRes = await this.mcp.callJiraTool(createTool, {
+            project: projectKey,
+            parent: params.task_id,
+            parentKey: params.task_id,
+            summary,
+            description,
+            issueType: "Sub-task",
+            issuetype: "Sub-task",
+            type: "Sub-task",
+          });
+          if (!createRes.isError && createRes.content) {
+            const keyMatch = createRes.content.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
+            if (keyMatch) {
+              subTasksCreated.push({ key: keyMatch[1], summary: ch.summary, priority: ch.priority });
+              nextSteps.push(`Address: ${ch.summary} (${keyMatch[1]})`);
+            }
+          }
+        }
+        if (subTasksCreated.length > 0) actions.push(`Created ${subTasksCreated.length} Jira sub-task(s) from review`);
+      }
+    }
+
+    const mrUrl = mr?.web_url ?? params.merge_request_url;
+    const commentParts: string[] = [`Handoff to **${params.to_dev}**`];
+    if (reviewAnalysis?.changesRequested) commentParts.push(`Review: ${reviewAnalysis.unresolvedThreads} item(s) to address.`);
+    if (subTasksCreated.length > 0) commentParts.push("Sub-tasks: " + subTasksCreated.map((s) => s.key).join(", "));
+    if (params.custom_notes) commentParts.push(params.custom_notes);
+    const extraComment = commentParts.join("\n");
+    await this.addMrCommentToJira(params.task_id, mrUrl ?? params.task_id, extraComment).catch(() => {});
+    actions.push("Added handoff comment to Jira");
+
+    const activeSession = await this.getActiveSession(params.from_dev);
+    const sessionDetails = activeSession?.jiraKey === params.task_id ? await this.db.getSession(activeSession.id) : null;
+    const title = `Handoff: ${params.task_id} → ${params.to_dev}`;
+    const handoffId = await this.createHandoff({
+      fromDeveloperId: params.from_dev,
+      toDeveloperId: params.to_dev,
+      title,
+      contextSummary: reviewAnalysis ? `${reviewAnalysis.unresolvedThreads} review item(s)` : undefined,
+      whatDone: params.custom_notes ?? (mr ? `MR !${mr.iid} ready for review` : undefined),
+      whatNext: nextSteps.length ? nextSteps.join("; ") : "Address review and push changes",
+      branchName: sessionDetails?.branch_name ?? undefined,
+      mergeRequestUrl: mrUrl,
+      jiraIssueKey: params.task_id,
+      workSessionId: activeSession?.jiraKey === params.task_id ? activeSession.id : undefined,
+    });
+    actions.push("Saved handoff record");
+
+    if (nextSteps.length === 0) nextSteps.push("Review MR", "Address any comments", "Request re-review");
+
+    // 3. Sync local state with Jira after actions (CRITICAL: Jira state awareness)
+    const syncResult = await this.syncLocalStateWithJira(params.task_id, jiraState, params.from_dev);
+    if (!syncResult.synced && syncResult.message) warnings.push(syncResult.message);
+
+    const estimatedMinutes = reviewAnalysis?.requiredChanges?.reduce((s, c) => s + c.estimatedMinutes, 0) ?? 30;
+    return {
+      summary: `Handoff created to ${params.to_dev}`,
+      actions_taken: actions,
+      next_steps: nextSteps,
+      data: {
+        handoff_id: handoffId,
+        task_id: params.task_id,
+        merge_request: mr ? { iid: mr.iid, url: mr.web_url, state: mr.state, has_conflicts: mr.has_conflicts, source_branch: mr.source_branch, target_branch: mr.target_branch } : undefined,
+        review_status: reviewAnalysis ? { changes_requested: reviewAnalysis.changesRequested, unresolved_threads: reviewAnalysis.unresolvedThreads, total_comments: reviewAnalysis.totalComments } : undefined,
+        sub_tasks_created: subTasksCreated,
+      },
+      warnings: warnings.length ? warnings : undefined,
+      estimated_effort_minutes: estimatedMinutes,
+    };
   }
 
   async endOfDay(developerId?: string): Promise<MorningCheckinResult & { message: string }> {
@@ -267,6 +632,148 @@ export class WorkflowManager {
       sessionDetails,
       microTasks,
       progressLogs,
+    };
+  }
+
+  /** Review Readiness: check Jira sub-tasks, GitLab pipeline/conflicts, work session. */
+  async reviewReadinessCheck(taskId: string, developerId?: string): Promise<ReviewReadinessResult> {
+    const devId = developerId ?? defaultDeveloperId();
+    const blockers: BlockerItem[] = [];
+    const readiness: ReviewReadinessResult["data"]["readiness"] = {
+      all_subtasks_complete: true,
+      tests_passing: true,
+      no_conflicts: true,
+      session_complete: true,
+    };
+
+    // 1. Query Jira for current state before any action (CRITICAL: Jira state awareness)
+    const jiraState = await this.getJiraState(taskId);
+    if (!jiraState) {
+      return {
+        summary: `${taskId} not found or Jira unavailable`,
+        actions_taken: [],
+        next_steps: ["Check issue key", "Ensure Jira MCP is connected"],
+        data: { readiness: { all_subtasks_complete: undefined, tests_passing: undefined, no_conflicts: undefined, session_complete: undefined }, blockers: [{ type: "jira", message: "Could not load Jira issue" }] },
+      };
+    }
+    if (jiraState.statusCategory?.toLowerCase() === "done" || jiraState.statusName?.toLowerCase() === "done") {
+      return {
+        summary: `${taskId} is already Done`,
+        actions_taken: [],
+        next_steps: ["No review needed for completed issue"],
+        data: { readiness: { all_subtasks_complete: true, tests_passing: true, no_conflicts: true, session_complete: true }, blockers: [{ type: "state", message: "Issue is Done" }] },
+      };
+    }
+
+    const [statusTool, activeRow] = await Promise.all([
+      this.mcp.getGitStatusTool(),
+      this.db.getActiveSession(devId),
+    ]);
+
+    const incomplete = jiraState.subtasks.filter((s) => s.statusCategory?.toLowerCase() !== "done" && s.statusName?.toLowerCase() !== "done");
+    if (incomplete.length > 0) {
+      readiness.all_subtasks_complete = false;
+      for (const s of incomplete) {
+        blockers.push({ type: "incomplete_subtask", task: s.key, message: s.statusName });
+      }
+    }
+
+    const gitStatusRes = await this.mcp.callGitTool(statusTool, { path: process.cwd(), repo_path: process.cwd() });
+
+    if (activeRow?.jira_issue_key === taskId) {
+      readiness.session_complete = false;
+      blockers.push({ type: "active_session", message: "Close or hand off your work session before requesting review" });
+    }
+
+    if (!gitStatusRes.isError && gitStatusRes.content && /conflict|CONFLICT|diverged/i.test(gitStatusRes.content)) {
+      readiness.no_conflicts = false;
+      blockers.push({ type: "merge_conflict", message: "Resolve merge conflicts before requesting review" });
+    } else if (gitStatusRes.isError) {
+      readiness.no_conflicts = undefined;
+    }
+
+    let mrUrl: string | undefined;
+    let pipelineOk: boolean | undefined;
+    const projectId = process.env["RELAY_GITLAB_PROJECT"];
+    if (projectId) {
+      const listMrTool = await this.mcp.getGitLabMergeRequestsTool();
+      const mrRes = await this.mcp.callGitTool(listMrTool, { project_id: projectId, state: "opened", limit: 10 });
+      if (!mrRes.isError && mrRes.content) {
+        try {
+          const data = JSON.parse(mrRes.content);
+          const list = Array.isArray(data) ? data : data?.merge_requests ?? [];
+          const taskIdUpper = taskId.toUpperCase();
+          const match = list.find((m: any) => (m.title && String(m.title).toUpperCase().includes(taskIdUpper)) || (m.source_branch && String(m.source_branch).toUpperCase().includes(taskIdUpper))) ?? list[0];
+          if (match) {
+            mrUrl = match.web_url ?? match.url;
+            pipelineOk = match.pipeline ? match.pipeline.status === "success" : undefined;
+            if (pipelineOk === false) {
+              readiness.tests_passing = false;
+              blockers.push({ type: "failing_test", message: "Pipeline not passing" });
+            }
+          }
+        } catch {
+          pipelineOk = undefined;
+        }
+      }
+    } else {
+      pipelineOk = undefined;
+    }
+
+    const allGood = readiness.all_subtasks_complete !== false && readiness.session_complete !== false && readiness.no_conflicts !== false && readiness.tests_passing !== false;
+    return {
+      summary: allGood ? `${taskId} is ready for review` : `${taskId} is not ready for review`,
+      actions_taken: allGood ? ["Ready to request reviewers"] : [],
+      next_steps: allGood ? ["Request reviewers on the MR", "Address any feedback"] : blockers.map((b) => (b.task ? `Complete ${b.task}` : b.message ?? b.type)),
+      data: { readiness, blockers: blockers.length ? blockers : undefined, mr_url: mrUrl },
+    };
+  }
+
+  /** Context Resurrection: last session + Jira + GitLab summary for returning developer. */
+  async contextResurrection(developerId?: string): Promise<{
+    summary: string;
+    lastSession: { id: string; jira_issue_key: string | null; jira_issue_summary: string | null; branch_name: string | null; ended_at: string | null } | null;
+    jiraCurrentState?: { key: string; statusName: string; statusCategory: string };
+    jiraUpdates: Array<{ task: string; change: string }>;
+    conflicts: Array<{ reason: string }>;
+    nextMicroTask?: string;
+    activeSession: boolean;
+  }> {
+    const devId = developerId ?? defaultDeveloperId();
+    const lastSessions = await this.db.getLastEndedSessions(devId, 3);
+    const last = lastSessions[0] ?? null;
+    if (!last) {
+      return { summary: "No previous work sessions found.", lastSession: null, jiraUpdates: [], conflicts: [], activeSession: (await this.db.getActiveSession(devId)) != null };
+    }
+
+    // 1. Query Jira for current state (CRITICAL: Jira state awareness) — auto-detect context from last session
+    const [microTasks, jiraState, gitStatusRes, activeRow] = await Promise.all([
+      this.db.getMicroTasks(last.id),
+      last.jira_issue_key ? this.getJiraState(last.jira_issue_key) : Promise.resolve(null),
+      this.mcp.getGitStatusTool().then((name) => this.mcp.callGitTool(name, { path: process.cwd(), repo_path: process.cwd() })),
+      this.db.getActiveSession(devId),
+    ]);
+
+    const jiraUpdates: Array<{ task: string; change: string }> = [];
+    if (jiraState && last.jira_issue_key) {
+      jiraUpdates.push({ task: last.jira_issue_key, change: `Current status: ${jiraState.statusName} (${jiraState.statusCategory})` });
+      if (jiraState.updated) jiraUpdates.push({ task: last.jira_issue_key, change: `Last updated: ${jiraState.updated}` });
+    }
+
+    const conflicts: Array<{ reason: string }> = [];
+    if (!gitStatusRes.isError && gitStatusRes.content && /conflict|CONFLICT|diverged/i.test(gitStatusRes.content)) {
+      conflicts.push({ reason: "Merge conflicts or diverged branch" });
+    }
+
+    const nextMicro = microTasks.find((t) => t.status !== "done");
+    return {
+      summary: "Welcome back. Here's what happened while you were away.",
+      lastSession: last,
+      jiraCurrentState: jiraState ? { key: jiraState.key, statusName: jiraState.statusName, statusCategory: jiraState.statusCategory } : undefined,
+      jiraUpdates,
+      conflicts,
+      nextMicroTask: nextMicro?.title,
+      activeSession: activeRow != null,
     };
   }
 }


### PR DESCRIPTION
Introduce a major orchestration feature set: adds orchestration flows and ~35 new orchestration tools (AI-driven, code-review, handoffs, deployment, metrics, onboarding, optimization, quality, security, sprint-planning, work-sessions, etc.), plus base orchestration helpers and types. Add Jira state-awareness (lib/jira-state.ts, base-orchestration-tool) and workflow manager integrations so tools query/validate/sync Jira state. Update DB adapter with getLastEndedSessions and getWorkSessionsForDeveloper to support context resurrection and analytics. Update API reference and add docs for Jira state awareness and MVP tool recommendations. Wire changes through orchestrator, workflow-manager, mcp-clients, server and index to expose the new tools.

## Description
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist
- [ ] Tests pass locally (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if needed)
- [ ] Follows branch convention (feature/*, release/*, hotfix/*)

## Related issues
<!-- Link any related issues: Fixes #123 -->
